### PR TITLE
ci: serialize Play Store release runs with a concurrency group

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,13 @@ on:
 permissions:
   contents: write
 
+# The Play Publishing API allows only one open edit per app, so concurrent
+# release runs (e.g. from a Dependabot merge batch) invalidate each other.
+# Serialize them; intermediate queued runs are superseded by the newest.
+concurrency:
+  group: play-store-release
+  cancel-in-progress: false
+
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=4 -Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dkotlin.incremental=false
 


### PR DESCRIPTION
## Why

Batches of Dependabot PRs merged minutes apart each trigger the release workflow, so several release runs upload to the Play Store simultaneously. The Play Publishing API allows only one open edit per app — when one run commits its edit, the others' open edits are invalidated and fail with:

> This edit has expired, please create a new Edit.

Example: https://github.com/arunderwood/heightmark/actions/runs/28552043146 — one of 3 failures out of 7 release runs started within three minutes on 2026-07-01. The failure clusters in Feb/Mar/May line up with earlier Dependabot batches the same way.

## What

Add a `concurrency` group to `release.yml` so release runs queue instead of racing.

Note: GitHub keeps one running + one pending run per group and cancels intermediates. That's the desired behavior here — the newest queued run has the highest `versionCode` and supersedes the others, so every merged commit is still covered by the release that does run. Superseded runs show as "cancelled" rather than green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)