### PR TITLE
ci: migrate deprecated 'track' input to 'tracks'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           packageName: com.bizzarosn.heightmark
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
-          track: internal
+          tracks: internal
           status: completed
           inAppUpdatePriority: 2
           whatsNewDirectory: metadata/whatsnew


### PR DESCRIPTION
r0adkll/upload-google-play deprecated the singular `track` input in favor of `tracks` — every release run currently logs:

> WARNING!! 'track' is deprecated and will be removed in a future release. Please migrate to 'tracks'

One-line rename, same behavior (`tracks` accepts a single track name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)