### PR TITLE
fix: display sea-level elevation instead of WGS84 ellipsoid height

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -3,8 +3,9 @@ name: Android CI
 on:
   push:
     branches: [ "main" ]
+  # No base-branch filter: stacked PRs (targeting another feature branch)
+  # need the same quality gates as PRs targeting main
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/app/src/main/java/com/bizzarosn/heightmark/AltitudeResolver.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/AltitudeResolver.kt
@@ -1,0 +1,50 @@
+package com.bizzarosn.heightmark
+
+import android.content.Context
+import android.location.Location
+import android.location.altitude.AltitudeConverter
+import android.util.Log
+import androidx.annotation.WorkerThread
+import java.io.IOException
+
+/**
+ * Resolves the elevation above Mean Sea Level for a GNSS fix.
+ *
+ * Raw [Location.getAltitude] is height above the WGS84 reference ellipsoid, which
+ * differs from sea-level elevation by roughly -100 m to +85 m depending on where on
+ * Earth the fix is. The platform [AltitudeConverter] corrects this using on-device
+ * geoid data, entirely offline.
+ *
+ * Keep a single instance: the converter caches geoid data between calls, so the
+ * first conversion in a region may take seconds while later ones are cheap.
+ */
+class AltitudeResolver(
+    private val context: Context,
+    private val converter: AltitudeConverter = AltitudeConverter()
+) {
+
+    /**
+     * Returns the location's elevation above Mean Sea Level in meters, falling back
+     * to the raw ellipsoid altitude if geoid data cannot be loaded.
+     *
+     * The location must have an altitude ([Location.hasAltitude]).
+     */
+    @WorkerThread
+    @Synchronized
+    fun mslAltitudeMeters(location: Location): Double {
+        return try {
+            converter.addMslAltitudeToLocation(context, location)
+            if (location.hasMslAltitude()) location.mslAltitudeMeters else location.altitude
+        } catch (e: IOException) {
+            Log.w(TAG, "Geoid data unavailable, using ellipsoid altitude", e)
+            location.altitude
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "Location rejected by AltitudeConverter, using ellipsoid altitude", e)
+            location.altitude
+        }
+    }
+
+    companion object {
+        private const val TAG = "AltitudeResolver"
+    }
+}

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
@@ -21,8 +21,10 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.button.MaterialButtonToggleGroup
 import com.google.android.material.loadingindicator.LoadingIndicator
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -36,6 +38,9 @@ class ElevationFragment : Fragment() {
 
     @Inject
     lateinit var locationManager: LocationManager
+
+    @Inject
+    lateinit var altitudeResolver: AltitudeResolver
 
     private lateinit var elevationTextView: TextView
     private lateinit var loadingIndicator: LoadingIndicator
@@ -126,10 +131,7 @@ class ElevationFragment : Fragment() {
             @Suppress("DEPRECATION", "DEPRECATION_ERROR")
             locationListener = object : LocationListener {
                 override fun onLocationChanged(location: Location) {
-                    val elevation = location.altitude
-                    elevationService.addElevationReading(elevation)
-                    hasFix = true
-                    updateUIWithElevation()
+                    onGnssFix(location)
                 }
 
                 @Deprecated("Deprecated in Java")
@@ -149,13 +151,10 @@ class ElevationFragment : Fragment() {
 
         locationListener?.let { listener ->
             try {
+                // Only GNSS fixes carry altitude, so the network provider is useless here
                 if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
                     locationManager.requestLocationUpdates(
                         LocationManager.GPS_PROVIDER, 1000, 1f, listener
-                    )
-                } else if (locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)) {
-                    locationManager.requestLocationUpdates(
-                        LocationManager.NETWORK_PROVIDER, 1000, 1f, listener
                     )
                 }
             } catch (e: SecurityException) {
@@ -163,6 +162,20 @@ class ElevationFragment : Fragment() {
                 Log.e("ElevationFragment", "Unexpected SecurityException despite permission check", e)
                 showPermissionRequired()
             }
+        }
+    }
+
+    private fun onGnssFix(location: Location) {
+        // A fix without altitude would read as 0.0 and poison the average
+        if (!location.hasAltitude()) return
+        viewLifecycleOwner.lifecycleScope.launch {
+            // Geoid data loads from disk on first use in a region
+            val elevation = withContext(Dispatchers.IO) {
+                altitudeResolver.mslAltitudeMeters(location)
+            }
+            elevationService.addElevationReading(elevation)
+            hasFix = true
+            updateUIWithElevation()
         }
     }
 

--- a/app/src/main/java/com/bizzarosn/heightmark/di/AppModule.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/di/AppModule.kt
@@ -2,6 +2,7 @@ package com.bizzarosn.heightmark.di
 
 import android.content.Context
 import android.location.LocationManager
+import com.bizzarosn.heightmark.AltitudeResolver
 import com.bizzarosn.heightmark.ElevationService
 import com.bizzarosn.heightmark.PreferencesRepository
 import dagger.Module
@@ -34,5 +35,13 @@ object AppModule {
         @ApplicationContext context: Context
     ): LocationManager {
         return context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+    }
+
+    @Provides
+    @Singleton
+    fun provideAltitudeResolver(
+        @ApplicationContext context: Context
+    ): AltitudeResolver {
+        return AltitudeResolver(context)
     }
 }

--- a/app/src/test/java/com/bizzarosn/heightmark/AltitudeResolverTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/AltitudeResolverTest.kt
@@ -1,0 +1,82 @@
+package com.bizzarosn.heightmark
+
+import android.content.Context
+import android.location.Location
+import android.location.altitude.AltitudeConverter
+import android.util.Log
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkStatic
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+class AltitudeResolverTest {
+
+    private lateinit var context: Context
+    private lateinit var converter: AltitudeConverter
+    private lateinit var resolver: AltitudeResolver
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.w(any(), any<String>(), any()) } returns 0
+        context = mockk()
+        converter = mockk()
+        resolver = AltitudeResolver(context, converter)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    private fun location(ellipsoid: Double, msl: Double? = null): Location {
+        val location = mockk<Location>()
+        every { location.altitude } returns ellipsoid
+        every { location.hasMslAltitude() } returns (msl != null)
+        if (msl != null) {
+            every { location.mslAltitudeMeters } returns msl
+        }
+        return location
+    }
+
+    @Test
+    fun `returns MSL altitude when conversion succeeds`() {
+        val location = location(ellipsoid = 100.0, msl = 121.5)
+        every { converter.addMslAltitudeToLocation(context, location) } just runs
+
+        assertEquals(121.5, resolver.mslAltitudeMeters(location), 0.001)
+    }
+
+    @Test
+    fun `falls back to ellipsoid altitude when converter does not populate MSL`() {
+        val location = location(ellipsoid = 100.0)
+        every { converter.addMslAltitudeToLocation(context, location) } just runs
+
+        assertEquals(100.0, resolver.mslAltitudeMeters(location), 0.001)
+    }
+
+    @Test
+    fun `falls back to ellipsoid altitude when geoid data cannot be loaded`() {
+        val location = location(ellipsoid = 100.0)
+        every { converter.addMslAltitudeToLocation(context, location) } throws IOException("no geoid data")
+
+        assertEquals(100.0, resolver.mslAltitudeMeters(location), 0.001)
+    }
+
+    @Test
+    fun `falls back to ellipsoid altitude when converter rejects the location`() {
+        val location = location(ellipsoid = 100.0)
+        every {
+            converter.addMslAltitudeToLocation(context, location)
+        } throws IllegalArgumentException("invalid latitude")
+
+        assertEquals(100.0, resolver.mslAltitudeMeters(location), 0.001)
+    }
+}


### PR DESCRIPTION
## Phase 1 of 4 — location API gap-filling plan

### Problem
The elevation shown to users is raw `Location.getAltitude()`, which is height above the **WGS84 reference ellipsoid**, not elevation above sea level. The geoid–ellipsoid separation ranges from −100 m to +85 m globally (about −20 m in the Pacific Northwest), so the displayed number is systematically wrong by tens of meters compared to maps and survey markers.

A second latent bug: the `NETWORK_PROVIDER` fallback can deliver fixes without altitude, for which `getAltitude()` returns `0.0` — silently poisoning the 10-reading rolling average on devices where GPS is toggled off but network location is on.

### Changes
- **New `AltitudeResolver`**: converts each GNSS fix to Mean Sea Level via the platform `android.location.altitude.AltitudeConverter` (API 34 — exactly our minSdk). Conversion uses on-device geoid data, fully offline, no Play services — identical behavior on certified and de-googled AOSP devices. Falls back to ellipsoid height if geoid data can't load. Runs on `Dispatchers.IO` (first conversion per region loads assets from disk).
- **`hasAltitude()` filter**: fixes without altitude are dropped instead of averaged as 0.0.
- **Removed `NETWORK_PROVIDER` fallback**: only GNSS provides altitude, so it could never serve this app's purpose (and it doesn't exist on de-googled AOSP anyway).

### Testing
- 4 new unit tests for `AltitudeResolver` (MSL success, unpopulated-MSL fallback, `IOException` fallback, invalid-location fallback); all 25 unit tests pass, lint clean, instrumented tests compile.
- Displayed elevation will shift by the local geoid offset — this is the fix working. Worth a manual sanity check against a known local elevation after the internal-track release.

Stacked series: Phase 2 (robustness/UX) → Phase 3 (motion-aware acquisition) → Phase 4 (details panel) will follow, each based on the previous.