### PR TITLE
feat: handle location-off, coarse-only grants, and slow GPS acquisition

### DIFF
--- a/app/src/androidTest/java/com/bizzarosn/heightmark/LocationPermissionTest.kt
+++ b/app/src/androidTest/java/com/bizzarosn/heightmark/LocationPermissionTest.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
@@ -71,11 +72,15 @@ class CoarseLocationPermissionTest {
     }
 
     @Test
-    fun appWorksWithCoarseLocationOnly() {
-        // Test app behavior with only coarse location permission
+    fun appPromptsForPreciseLocationWithCoarseOnly() {
+        // Approximate-only grants can't drive GPS, so the app should ask the user
+        // to upgrade to precise location
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
-            onView(withId(R.id.elevation_text_view)).check(matches(isDisplayed()))
-            onView(withId(R.id.unit_toggle_group)).check(matches(isDisplayed()))
+            // The permission check runs after an async preferences read
+            Thread.sleep(2000)
+            onView(withText(R.string.precise_location_required))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
         }
     }
 }

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
@@ -1,12 +1,17 @@
 package com.bizzarosn.heightmark
 
 import android.Manifest
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
 import android.os.Bundle
 import android.graphics.Color
+import android.provider.Settings
 import android.util.Log
 import android.util.TypedValue
 import android.view.LayoutInflater
@@ -16,8 +21,11 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.TextViewCompat
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import com.google.android.material.button.MaterialButtonToggleGroup
 import com.google.android.material.loadingindicator.LoadingIndicator
 import dagger.hilt.android.AndroidEntryPoint
@@ -47,8 +55,25 @@ class ElevationFragment : Fragment() {
     private var useMetricUnit = true
     private var hasFix = false
     private var locationListener: LocationListener? = null
+    private var searchTimeoutJob: Job? = null
+    private var locationOffDialog: AlertDialog? = null
 
     private lateinit var permissionHandler: LocationPermissionHandler
+
+    private val providersChangedReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action != LocationManager.PROVIDERS_CHANGED_ACTION) return
+            if (!permissionHandler.hasFinePermission()) return
+            if (isGpsAvailable()) {
+                locationOffDialog?.dismiss()
+                locationOffDialog = null
+                startLocationUpdates()
+            } else {
+                stopLocationUpdates()
+                showLocationOff()
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -97,6 +122,10 @@ class ElevationFragment : Fragment() {
                     showPermissionRequired()
                 }
             }
+            is LocationPermissionState.CoarseOnly -> {
+                stopLocationUpdates()
+                showPreciseLocationRequired()
+            }
             is LocationPermissionState.Denied,
             is LocationPermissionState.PermanentlyDenied -> {
                 stopLocationUpdates()
@@ -113,17 +142,23 @@ class ElevationFragment : Fragment() {
         return ContextCompat.checkSelfPermission(
             requireContext(),
             Manifest.permission.ACCESS_FINE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED ||
-        ContextCompat.checkSelfPermission(
-            requireContext(),
-            Manifest.permission.ACCESS_COARSE_LOCATION
         ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun isGpsAvailable(): Boolean {
+        return locationManager.isLocationEnabled &&
+            locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
     }
 
     private fun startLocationUpdates() {
         // Double-check permissions before starting location updates
         if (!hasLocationPermission()) {
             showPermissionRequired()
+            return
+        }
+
+        if (!isGpsAvailable()) {
+            showLocationOff()
             return
         }
 
@@ -152,15 +187,25 @@ class ElevationFragment : Fragment() {
         locationListener?.let { listener ->
             try {
                 // Only GNSS fixes carry altitude, so the network provider is useless here
-                if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
-                    locationManager.requestLocationUpdates(
-                        LocationManager.GPS_PROVIDER, 1000, 1f, listener
-                    )
-                }
+                locationManager.requestLocationUpdates(
+                    LocationManager.GPS_PROVIDER, 1000, 1f, listener
+                )
+                startSearchTimeout()
             } catch (e: SecurityException) {
                 // Log the unexpected security exception for debugging
                 Log.e("ElevationFragment", "Unexpected SecurityException despite permission check", e)
                 showPermissionRequired()
+            }
+        }
+    }
+
+    private fun startSearchTimeout() {
+        if (hasFix) return
+        searchTimeoutJob?.cancel()
+        searchTimeoutJob = viewLifecycleOwner.lifecycleScope.launch {
+            delay(SEARCH_TIMEOUT_MS)
+            if (!hasFix) {
+                showStatusText(getString(R.string.still_searching))
             }
         }
     }
@@ -180,6 +225,8 @@ class ElevationFragment : Fragment() {
     }
 
     private fun stopLocationUpdates() {
+        searchTimeoutJob?.cancel()
+        searchTimeoutJob = null
         locationListener?.let { listener ->
             locationManager.removeUpdates(listener)
         }
@@ -187,11 +234,21 @@ class ElevationFragment : Fragment() {
 
     override fun onPause() {
         super.onPause()
+        requireContext().unregisterReceiver(providersChangedReceiver)
+        locationOffDialog?.dismiss()
+        locationOffDialog = null
         stopLocationUpdates()
     }
 
     override fun onResume() {
         super.onResume()
+        // System broadcast, so RECEIVER_NOT_EXPORTED still receives it
+        ContextCompat.registerReceiver(
+            requireContext(),
+            providersChangedReceiver,
+            IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
         if (hasLocationPermission()) {
             startLocationUpdates()
         }
@@ -207,6 +264,27 @@ class ElevationFragment : Fragment() {
     private fun showPermissionRequired() {
         setLoading(false)
         showStatusText(getString(R.string.location_permission_required))
+    }
+
+    private fun showPreciseLocationRequired() {
+        setLoading(false)
+        showStatusText(getString(R.string.precise_location_required))
+    }
+
+    private fun showLocationOff() {
+        setLoading(false)
+        showStatusText(getString(R.string.location_services_off))
+
+        if (locationOffDialog?.isShowing == true) return
+        locationOffDialog = AlertDialog.Builder(requireContext())
+            .setTitle(getString(R.string.location_services_off))
+            .setMessage(getString(R.string.location_services_off_message))
+            .setPositiveButton(getString(R.string.open_location_settings)) { _, _ ->
+                startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .create()
+        locationOffDialog?.show()
     }
 
     // Status messages use headline type; the hero display size is reserved for the value
@@ -238,5 +316,9 @@ class ElevationFragment : Fragment() {
         super.onDestroy()
         stopLocationUpdates()
         locationListener = null
+    }
+
+    companion object {
+        private const val SEARCH_TIMEOUT_MS = 30_000L
     }
 }

--- a/app/src/main/java/com/bizzarosn/heightmark/LocationPermissionHandler.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/LocationPermissionHandler.kt
@@ -15,6 +15,9 @@ import androidx.lifecycle.LifecycleOwner
 
 sealed class LocationPermissionState {
     object Granted : LocationPermissionState()
+
+    /** Only approximate location granted (Android 12+ downgrade); GPS needs precise. */
+    object CoarseOnly : LocationPermissionState()
     object Denied : LocationPermissionState()
     object PermanentlyDenied : LocationPermissionState()
     object RequiresRationale : LocationPermissionState()
@@ -27,7 +30,8 @@ class LocationPermissionHandler(
     
     private var locationPermissionLauncher: ActivityResultLauncher<Array<String>>? = null
     private var currentDialog: AlertDialog? = null
-    
+    private var upgradeDialogShown = false
+
     private val permissions = arrayOf(
         Manifest.permission.ACCESS_FINE_LOCATION,
         Manifest.permission.ACCESS_COARSE_LOCATION
@@ -50,27 +54,39 @@ class LocationPermissionHandler(
     
     fun checkPermission() {
         when {
-            hasLocationPermission() -> {
+            hasFinePermission() -> {
                 onPermissionStateChanged(LocationPermissionState.Granted)
             }
-            
+
+            hasLocationPermission() -> {
+                // Approximate-only grant: GPS (and therefore elevation) needs precise
+                onPermissionStateChanged(LocationPermissionState.CoarseOnly)
+                showPreciseUpgradeDialog()
+            }
+
             shouldShowRationale() -> {
                 onPermissionStateChanged(LocationPermissionState.RequiresRationale)
                 showPermissionRequiredDialog()
             }
-            
+
             else -> {
                 requestPermissions()
             }
         }
     }
-    
+
     fun hasLocationPermission(): Boolean {
         return permissions.any { permission ->
             ContextCompat.checkSelfPermission(
                 fragment.requireContext(), permission
             ) == PackageManager.PERMISSION_GRANTED
         }
+    }
+
+    fun hasFinePermission(): Boolean {
+        return ContextCompat.checkSelfPermission(
+            fragment.requireContext(), Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
     }
     
     private fun shouldShowRationale(): Boolean {
@@ -85,20 +101,47 @@ class LocationPermissionHandler(
     
     private fun handlePermissionResult(permissions: Map<String, Boolean>) {
         when {
-            permissions.values.any { it } -> {
+            permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true -> {
                 onPermissionStateChanged(LocationPermissionState.Granted)
             }
-            
+
+            permissions.values.any { it } -> {
+                onPermissionStateChanged(LocationPermissionState.CoarseOnly)
+                showPreciseUpgradeDialog()
+            }
+
             shouldShowRationale() -> {
                 onPermissionStateChanged(LocationPermissionState.RequiresRationale)
                 showPermissionRequiredDialog()
             }
-            
+
             else -> {
                 onPermissionStateChanged(LocationPermissionState.PermanentlyDenied)
                 showPermanentDenialDialog()
             }
         }
+    }
+
+    private fun showPreciseUpgradeDialog() {
+        // Ask once per session; re-requesting in a loop would just re-show the
+        // system dialog every time the fragment resumes
+        if (upgradeDialogShown) return
+        if (currentDialog?.isShowing == true) return
+        upgradeDialogShown = true
+
+        currentDialog = AlertDialog.Builder(fragment.requireContext())
+            .setTitle(fragment.getString(R.string.precise_location_required))
+            .setMessage(fragment.getString(R.string.precise_location_required_message))
+            .setPositiveButton(fragment.getString(R.string.grant_permission)) { _, _ ->
+                requestPermissions()
+            }
+            .setNegativeButton(fragment.getString(R.string.open_settings)) { _, _ ->
+                openAppSettings()
+            }
+            .setCancelable(false)
+            .create()
+
+        currentDialog?.show()
     }
     
     private fun showPermissionRequiredDialog() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,10 @@
     <string name="exit_app">Exit App</string>
     <string name="permission_permanently_denied_message">This app needs location permission to determine your elevation. Please open settings and enable location permission manually.</string>
     <string name="open_settings">Open Settings</string>
+    <string name="precise_location_required">Precise Location Required</string>
+    <string name="precise_location_required_message">Elevation comes from GPS, which needs precise location. Approximate location isn\'t enough. Please allow precise location.</string>
+    <string name="location_services_off">Location Is Off</string>
+    <string name="location_services_off_message">Turn on location to determine your elevation.</string>
+    <string name="open_location_settings">Open Location Settings</string>
+    <string name="still_searching">Still searching for GPS signal… This works best outdoors with a clear view of the sky.</string>
 </resources>

--- a/app/src/test/java/com/bizzarosn/heightmark/LocationPermissionHandlerUnitTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/LocationPermissionHandlerUnitTest.kt
@@ -32,6 +32,7 @@ class LocationPermissionHandlerUnitTest {
         val testState = LocationPermissionState.Denied
         val result = when (testState) {
             is LocationPermissionState.Granted -> "access granted"
+            is LocationPermissionState.CoarseOnly -> "coarse only"
             is LocationPermissionState.Denied -> "access denied"
             is LocationPermissionState.PermanentlyDenied -> "permanently denied"
             is LocationPermissionState.RequiresRationale -> "requires rationale"


### PR DESCRIPTION
## Phase 2 of 4 — location API gap-filling plan (stacked on #193)

### Problems addressed
1. **Location services off → infinite spinner.** If location (or the GPS provider) is disabled, `startLocationUpdates()` registered nothing and the UI spun forever.
2. **Android 12+ approximate-only grants dead-ended.** `GPS_PROVIDER` requires `ACCESS_FINE_LOCATION`; with a coarse-only grant the app hit a `SecurityException` and showed a generic 'permission required' message with no path forward.
3. **No feedback during slow GPS acquisition** (indoors, urban canyon).

### Changes
- `isLocationEnabled`/`isProviderEnabled` check before requesting updates; when off, a dialog routes to `ACTION_LOCATION_SOURCE_SETTINGS` and a `PROVIDERS_CHANGED_ACTION` receiver (registered only while resumed) auto-recovers when the user re-enables location.
- New `LocationPermissionState.CoarseOnly`: detected on both the initial check and the request result; shows a once-per-session upgrade dialog (re-request → system shows the precise/approximate chooser) with a Settings fallback. The fragment's permission gate is now fine-only, preventing the `SecurityException` path entirely.
- 30-second search timeout swaps the status text to a 'still searching — works best outdoors' hint (GPS keeps listening).

### Testing
- Updated the sealed-state unit test for `CoarseOnly`; all unit tests pass, lint clean.
- Rewrote `appWorksWithCoarseLocationOnly` → `appPromptsForPreciseLocationWithCoarseOnly` to assert the upgrade dialog, since the coarse-only UX intentionally changed.