### PR TITLE
feat: motion-aware GPS duty cycling and modern location request API

### DIFF
--- a/app/src/androidTest/java/com/bizzarosn/heightmark/LocationPermissionTest.kt
+++ b/app/src/androidTest/java/com/bizzarosn/heightmark/LocationPermissionTest.kt
@@ -1,7 +1,10 @@
 package com.bizzarosn.heightmark
 
 import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
 import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.RootMatchers.isDialog
@@ -10,6 +13,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assume.assumeFalse
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -73,6 +77,17 @@ class CoarseLocationPermissionTest {
 
     @Test
     fun appPromptsForPreciseLocationWithCoarseOnly() {
+        // GrantPermissionRule grants persist for the whole instrumentation run, so
+        // when another test class has already granted FINE this coarse-only
+        // scenario can't be exercised — skip rather than assert the wrong flow.
+        // The assertion runs when this class executes in isolation.
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        assumeFalse(
+            "FINE already granted by an earlier test; coarse-only flow unavailable",
+            context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
+                PackageManager.PERMISSION_GRANTED
+        )
+
         // Approximate-only grants can't drive GPS, so the app should ask the user
         // to upgrade to precise location
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->

--- a/app/src/androidTest/java/com/bizzarosn/heightmark/LocationPermissionTest.kt
+++ b/app/src/androidTest/java/com/bizzarosn/heightmark/LocationPermissionTest.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
@@ -71,11 +72,15 @@ class CoarseLocationPermissionTest {
     }
 
     @Test
-    fun appWorksWithCoarseLocationOnly() {
-        // Test app behavior with only coarse location permission
+    fun appPromptsForPreciseLocationWithCoarseOnly() {
+        // Approximate-only grants can't drive GPS, so the app should ask the user
+        // to upgrade to precise location
         ActivityScenario.launch(MainActivity::class.java).use { scenario ->
-            onView(withId(R.id.elevation_text_view)).check(matches(isDisplayed()))
-            onView(withId(R.id.unit_toggle_group)).check(matches(isDisplayed()))
+            // The permission check runs after an async preferences read
+            Thread.sleep(2000)
+            onView(withText(R.string.precise_location_required))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
         }
     }
 }

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
+import android.location.LocationRequest
 import android.os.Bundle
 import android.graphics.Color
 import android.provider.Settings
@@ -50,6 +51,9 @@ class ElevationFragment : Fragment() {
     @Inject
     lateinit var altitudeResolver: AltitudeResolver
 
+    @Inject
+    lateinit var idleWakeMonitor: IdleWakeMonitor
+
     private lateinit var elevationTextView: TextView
     private lateinit var loadingIndicator: LoadingIndicator
     private var useMetricUnit = true
@@ -57,6 +61,7 @@ class ElevationFragment : Fragment() {
     private var locationListener: LocationListener? = null
     private var searchTimeoutJob: Job? = null
     private var locationOffDialog: AlertDialog? = null
+    private val stillnessDetector = StillnessDetector()
 
     private lateinit var permissionHandler: LocationPermissionHandler
 
@@ -163,21 +168,7 @@ class ElevationFragment : Fragment() {
         }
 
         if (locationListener == null) {
-            @Suppress("DEPRECATION", "DEPRECATION_ERROR")
-            locationListener = object : LocationListener {
-                override fun onLocationChanged(location: Location) {
-                    onGnssFix(location)
-                }
-
-                @Deprecated("Deprecated in Java")
-                override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) {}
-
-                @Deprecated("Deprecated in Java")
-                override fun onProviderEnabled(provider: String) {}
-
-                @Deprecated("Deprecated in Java")
-                override fun onProviderDisabled(provider: String) {}
-            }
+            locationListener = LocationListener { location -> onGnssFix(location) }
         }
 
         if (!hasFix) {
@@ -186,9 +177,16 @@ class ElevationFragment : Fragment() {
 
         locationListener?.let { listener ->
             try {
-                // Only GNSS fixes carry altitude, so the network provider is useless here
+                // Only GNSS fixes carry altitude, so the network provider is useless here.
+                // No min update distance: stillness detection needs fixes while parked.
+                val request = LocationRequest.Builder(UPDATE_INTERVAL_MS)
+                    .setQuality(LocationRequest.QUALITY_HIGH_ACCURACY)
+                    .build()
                 locationManager.requestLocationUpdates(
-                    LocationManager.GPS_PROVIDER, 1000, 1f, listener
+                    LocationManager.GPS_PROVIDER,
+                    request,
+                    ContextCompat.getMainExecutor(requireContext()),
+                    listener
                 )
                 startSearchTimeout()
             } catch (e: SecurityException) {
@@ -211,8 +209,18 @@ class ElevationFragment : Fragment() {
     }
 
     private fun onGnssFix(location: Location) {
+        if (stillnessDetector.feed(location)) {
+            goIdle(location)
+        }
+
         // A fix without altitude would read as 0.0 and poison the average
         if (!location.hasAltitude()) return
+        // Skip fixes whose vertical error would drag the average around
+        if (location.hasVerticalAccuracy() &&
+            location.verticalAccuracyMeters > MAX_VERTICAL_ACCURACY_M
+        ) {
+            return
+        }
         viewLifecycleOwner.lifecycleScope.launch {
             // Geoid data loads from disk on first use in a region
             val elevation = withContext(Dispatchers.IO) {
@@ -224,7 +232,35 @@ class ElevationFragment : Fragment() {
         }
     }
 
+    /**
+     * The device has been still for a while: turn the GPS radio off and let
+     * [IdleWakeMonitor] (significant motion, barometer, passive fixes) turn it
+     * back on when we move. The displayed elevation stays frozen meanwhile.
+     */
+    private fun goIdle(anchor: Location) {
+        if (idleWakeMonitor.isRunning) return
+        stopLocationUpdates()
+        try {
+            idleWakeMonitor.start(
+                anchor,
+                ContextCompat.getMainExecutor(requireContext()),
+                viewLifecycleOwner.lifecycleScope
+            ) {
+                goActive()
+            }
+        } catch (e: SecurityException) {
+            Log.e("ElevationFragment", "Lost permission while going idle", e)
+            showPermissionRequired()
+        }
+    }
+
+    private fun goActive() {
+        stillnessDetector.reset()
+        startLocationUpdates()
+    }
+
     private fun stopLocationUpdates() {
+        idleWakeMonitor.stop()
         searchTimeoutJob?.cancel()
         searchTimeoutJob = null
         locationListener?.let { listener ->
@@ -250,6 +286,7 @@ class ElevationFragment : Fragment() {
             ContextCompat.RECEIVER_NOT_EXPORTED
         )
         if (hasLocationPermission()) {
+            stillnessDetector.reset()
             startLocationUpdates()
         }
     }
@@ -320,5 +357,7 @@ class ElevationFragment : Fragment() {
 
     companion object {
         private const val SEARCH_TIMEOUT_MS = 30_000L
+        private const val UPDATE_INTERVAL_MS = 1_000L
+        private const val MAX_VERTICAL_ACCURACY_M = 50f
     }
 }

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
@@ -1,12 +1,17 @@
 package com.bizzarosn.heightmark
 
 import android.Manifest
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
 import android.os.Bundle
 import android.graphics.Color
+import android.provider.Settings
 import android.util.Log
 import android.util.TypedValue
 import android.view.LayoutInflater
@@ -16,8 +21,11 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.TextViewCompat
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import com.google.android.material.button.MaterialButtonToggleGroup
 import com.google.android.material.loadingindicator.LoadingIndicator
 import dagger.hilt.android.AndroidEntryPoint
@@ -47,8 +55,25 @@ class ElevationFragment : Fragment() {
     private var useMetricUnit = true
     private var hasFix = false
     private var locationListener: LocationListener? = null
+    private var searchTimeoutJob: Job? = null
+    private var locationOffDialog: AlertDialog? = null
 
     private lateinit var permissionHandler: LocationPermissionHandler
+
+    private val providersChangedReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action != LocationManager.PROVIDERS_CHANGED_ACTION) return
+            if (!permissionHandler.hasFinePermission()) return
+            if (isGpsAvailable()) {
+                locationOffDialog?.dismiss()
+                locationOffDialog = null
+                startLocationUpdates()
+            } else {
+                stopLocationUpdates()
+                showLocationOff()
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -97,6 +122,10 @@ class ElevationFragment : Fragment() {
                     showPermissionRequired()
                 }
             }
+            is LocationPermissionState.CoarseOnly -> {
+                stopLocationUpdates()
+                showPreciseLocationRequired()
+            }
             is LocationPermissionState.Denied,
             is LocationPermissionState.PermanentlyDenied -> {
                 stopLocationUpdates()
@@ -113,17 +142,23 @@ class ElevationFragment : Fragment() {
         return ContextCompat.checkSelfPermission(
             requireContext(),
             Manifest.permission.ACCESS_FINE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED ||
-        ContextCompat.checkSelfPermission(
-            requireContext(),
-            Manifest.permission.ACCESS_COARSE_LOCATION
         ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun isGpsAvailable(): Boolean {
+        return locationManager.isLocationEnabled &&
+            locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
     }
 
     private fun startLocationUpdates() {
         // Double-check permissions before starting location updates
         if (!hasLocationPermission()) {
             showPermissionRequired()
+            return
+        }
+
+        if (!isGpsAvailable()) {
+            showLocationOff()
             return
         }
 
@@ -152,15 +187,25 @@ class ElevationFragment : Fragment() {
         locationListener?.let { listener ->
             try {
                 // Only GNSS fixes carry altitude, so the network provider is useless here
-                if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
-                    locationManager.requestLocationUpdates(
-                        LocationManager.GPS_PROVIDER, 1000, 1f, listener
-                    )
-                }
+                locationManager.requestLocationUpdates(
+                    LocationManager.GPS_PROVIDER, 1000, 1f, listener
+                )
+                startSearchTimeout()
             } catch (e: SecurityException) {
                 // Log the unexpected security exception for debugging
                 Log.e("ElevationFragment", "Unexpected SecurityException despite permission check", e)
                 showPermissionRequired()
+            }
+        }
+    }
+
+    private fun startSearchTimeout() {
+        if (hasFix) return
+        searchTimeoutJob?.cancel()
+        searchTimeoutJob = viewLifecycleOwner.lifecycleScope.launch {
+            delay(SEARCH_TIMEOUT_MS)
+            if (!hasFix) {
+                showStatusText(getString(R.string.still_searching))
             }
         }
     }
@@ -180,6 +225,8 @@ class ElevationFragment : Fragment() {
     }
 
     private fun stopLocationUpdates() {
+        searchTimeoutJob?.cancel()
+        searchTimeoutJob = null
         locationListener?.let { listener ->
             locationManager.removeUpdates(listener)
         }
@@ -187,11 +234,21 @@ class ElevationFragment : Fragment() {
 
     override fun onPause() {
         super.onPause()
+        requireContext().unregisterReceiver(providersChangedReceiver)
+        locationOffDialog?.dismiss()
+        locationOffDialog = null
         stopLocationUpdates()
     }
 
     override fun onResume() {
         super.onResume()
+        // System broadcast, so RECEIVER_NOT_EXPORTED still receives it
+        ContextCompat.registerReceiver(
+            requireContext(),
+            providersChangedReceiver,
+            IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
         if (hasLocationPermission()) {
             startLocationUpdates()
         }
@@ -207,6 +264,27 @@ class ElevationFragment : Fragment() {
     private fun showPermissionRequired() {
         setLoading(false)
         showStatusText(getString(R.string.location_permission_required))
+    }
+
+    private fun showPreciseLocationRequired() {
+        setLoading(false)
+        showStatusText(getString(R.string.precise_location_required))
+    }
+
+    private fun showLocationOff() {
+        setLoading(false)
+        showStatusText(getString(R.string.location_services_off))
+
+        if (locationOffDialog?.isShowing == true) return
+        locationOffDialog = AlertDialog.Builder(requireContext())
+            .setTitle(getString(R.string.location_services_off))
+            .setMessage(getString(R.string.location_services_off_message))
+            .setPositiveButton(getString(R.string.open_location_settings)) { _, _ ->
+                startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .create()
+        locationOffDialog?.show()
     }
 
     // Status messages use headline type; the hero display size is reserved for the value
@@ -238,5 +316,9 @@ class ElevationFragment : Fragment() {
         super.onDestroy()
         stopLocationUpdates()
         locationListener = null
+    }
+
+    companion object {
+        private const val SEARCH_TIMEOUT_MS = 30_000L
     }
 }

--- a/app/src/main/java/com/bizzarosn/heightmark/IdleWakeMonitor.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/IdleWakeMonitor.kt
@@ -1,0 +1,183 @@
+package com.bizzarosn.heightmark
+
+import android.Manifest
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.hardware.TriggerEvent
+import android.hardware.TriggerEventListener
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.location.LocationRequest
+import android.os.CancellationSignal
+import android.util.Log
+import androidx.annotation.RequiresPermission
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.Executor
+
+/**
+ * Watches for the device leaving a stationary position while the GPS radio is
+ * off, and fires [onWake] (once) when it should be turned back on.
+ *
+ * Wake triggers, each skipped gracefully when the hardware lacks it:
+ *  - significant-motion sensor: horizontal movement (walking or driving away).
+ *    Its platform contract only covers horizontal travel, so it can miss
+ *    elevators — hence the barometer.
+ *  - barometer: sustained pressure change means vertical movement.
+ *  - passive provider: free fixes other apps request; wake if one shows we moved.
+ *  - fallback GPS poll every few minutes, only on devices with no barometer,
+ *    to catch vertical movement the other triggers can't see.
+ */
+class IdleWakeMonitor(
+    private val locationManager: LocationManager,
+    private val sensorManager: SensorManager
+) {
+    private val pressureDetector = PressureDeltaDetector()
+    private var onWake: (() -> Unit)? = null
+    private var anchor: Location? = null
+
+    private var triggerListener: TriggerEventListener? = null
+    private var pressureListener: SensorEventListener? = null
+    private var passiveListener: LocationListener? = null
+    private var pollJob: Job? = null
+    private var pollCancellation: CancellationSignal? = null
+
+    val isRunning: Boolean
+        get() = onWake != null
+
+    /**
+     * Starts watching. [anchor] is the fix the device went idle at; [executor]
+     * receives location callbacks and [scope] hosts the fallback poll.
+     */
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+    fun start(anchor: Location, executor: Executor, scope: CoroutineScope, onWake: () -> Unit) {
+        stop()
+        this.anchor = anchor
+        this.onWake = onWake
+
+        armSignificantMotion()
+        val hasBarometer = armBarometer()
+        armPassiveProvider(executor)
+        if (!hasBarometer) {
+            startFallbackPoll(executor, scope)
+        }
+    }
+
+    fun stop() {
+        onWake = null
+        anchor = null
+
+        triggerListener?.let { listener ->
+            sensorManager.getDefaultSensor(Sensor.TYPE_SIGNIFICANT_MOTION)?.let { sensor ->
+                sensorManager.cancelTriggerSensor(listener, sensor)
+            }
+        }
+        triggerListener = null
+
+        pressureListener?.let { sensorManager.unregisterListener(it) }
+        pressureListener = null
+        pressureDetector.reset()
+
+        passiveListener?.let { locationManager.removeUpdates(it) }
+        passiveListener = null
+
+        pollJob?.cancel()
+        pollJob = null
+        pollCancellation?.cancel()
+        pollCancellation = null
+    }
+
+    private fun wake() {
+        val callback = onWake ?: return
+        stop()
+        callback()
+    }
+
+    private fun armSignificantMotion() {
+        val sensor = sensorManager.getDefaultSensor(Sensor.TYPE_SIGNIFICANT_MOTION) ?: return
+        val listener = object : TriggerEventListener() {
+            override fun onTrigger(event: TriggerEvent?) {
+                Log.d(TAG, "Significant motion detected")
+                wake()
+            }
+        }
+        if (sensorManager.requestTriggerSensor(listener, sensor)) {
+            triggerListener = listener
+        }
+    }
+
+    /** Returns true if a barometer is present and armed. */
+    private fun armBarometer(): Boolean {
+        val sensor = sensorManager.getDefaultSensor(Sensor.TYPE_PRESSURE) ?: return false
+        val listener = object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent) {
+                if (pressureDetector.feed(event.values[0])) {
+                    Log.d(TAG, "Sustained pressure change detected")
+                    wake()
+                }
+            }
+
+            override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+        }
+        val registered = sensorManager.registerListener(
+            listener, sensor, PRESSURE_SAMPLING_PERIOD_US
+        )
+        if (registered) {
+            pressureListener = listener
+        }
+        return registered
+    }
+
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+    private fun armPassiveProvider(executor: Executor) {
+        if (!locationManager.hasProvider(LocationManager.PASSIVE_PROVIDER)) return
+        val listener = LocationListener { location -> onOpportunisticFix(location) }
+        val request = LocationRequest.Builder(PASSIVE_INTERVAL_MS).build()
+        locationManager.requestLocationUpdates(
+            LocationManager.PASSIVE_PROVIDER, request, executor, listener
+        )
+        passiveListener = listener
+    }
+
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+    private fun startFallbackPoll(executor: Executor, scope: CoroutineScope) {
+        pollJob = scope.launch {
+            while (true) {
+                delay(FALLBACK_POLL_INTERVAL_MS)
+                if (onWake == null) return@launch
+                val cancellation = CancellationSignal()
+                pollCancellation = cancellation
+                locationManager.getCurrentLocation(
+                    LocationManager.GPS_PROVIDER, cancellation, executor
+                ) { location ->
+                    location?.let { onOpportunisticFix(it) }
+                }
+            }
+        }
+    }
+
+    private fun onOpportunisticFix(location: Location) {
+        val anchor = anchor ?: return
+        val movedHorizontally = anchor.distanceTo(location) > MAX_IDLE_DRIFT_METERS
+        val movedVertically = anchor.hasAltitude() && location.hasAltitude() &&
+            kotlin.math.abs(anchor.altitude - location.altitude) > MAX_IDLE_ALTITUDE_DRIFT_METERS
+        if (movedHorizontally || movedVertically) {
+            Log.d(TAG, "Opportunistic fix shows movement")
+            wake()
+        }
+    }
+
+    companion object {
+        private const val TAG = "IdleWakeMonitor"
+        private const val PRESSURE_SAMPLING_PERIOD_US = 1_000_000 // 1 Hz
+        private const val PASSIVE_INTERVAL_MS = 10_000L
+        private const val FALLBACK_POLL_INTERVAL_MS = 180_000L // 3 min
+        private const val MAX_IDLE_DRIFT_METERS = 30f
+        private const val MAX_IDLE_ALTITUDE_DRIFT_METERS = 10.0
+    }
+}

--- a/app/src/main/java/com/bizzarosn/heightmark/LocationPermissionHandler.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/LocationPermissionHandler.kt
@@ -15,6 +15,9 @@ import androidx.lifecycle.LifecycleOwner
 
 sealed class LocationPermissionState {
     object Granted : LocationPermissionState()
+
+    /** Only approximate location granted (Android 12+ downgrade); GPS needs precise. */
+    object CoarseOnly : LocationPermissionState()
     object Denied : LocationPermissionState()
     object PermanentlyDenied : LocationPermissionState()
     object RequiresRationale : LocationPermissionState()
@@ -27,7 +30,8 @@ class LocationPermissionHandler(
     
     private var locationPermissionLauncher: ActivityResultLauncher<Array<String>>? = null
     private var currentDialog: AlertDialog? = null
-    
+    private var upgradeDialogShown = false
+
     private val permissions = arrayOf(
         Manifest.permission.ACCESS_FINE_LOCATION,
         Manifest.permission.ACCESS_COARSE_LOCATION
@@ -50,27 +54,39 @@ class LocationPermissionHandler(
     
     fun checkPermission() {
         when {
-            hasLocationPermission() -> {
+            hasFinePermission() -> {
                 onPermissionStateChanged(LocationPermissionState.Granted)
             }
-            
+
+            hasLocationPermission() -> {
+                // Approximate-only grant: GPS (and therefore elevation) needs precise
+                onPermissionStateChanged(LocationPermissionState.CoarseOnly)
+                showPreciseUpgradeDialog()
+            }
+
             shouldShowRationale() -> {
                 onPermissionStateChanged(LocationPermissionState.RequiresRationale)
                 showPermissionRequiredDialog()
             }
-            
+
             else -> {
                 requestPermissions()
             }
         }
     }
-    
+
     fun hasLocationPermission(): Boolean {
         return permissions.any { permission ->
             ContextCompat.checkSelfPermission(
                 fragment.requireContext(), permission
             ) == PackageManager.PERMISSION_GRANTED
         }
+    }
+
+    fun hasFinePermission(): Boolean {
+        return ContextCompat.checkSelfPermission(
+            fragment.requireContext(), Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
     }
     
     private fun shouldShowRationale(): Boolean {
@@ -85,20 +101,47 @@ class LocationPermissionHandler(
     
     private fun handlePermissionResult(permissions: Map<String, Boolean>) {
         when {
-            permissions.values.any { it } -> {
+            permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true -> {
                 onPermissionStateChanged(LocationPermissionState.Granted)
             }
-            
+
+            permissions.values.any { it } -> {
+                onPermissionStateChanged(LocationPermissionState.CoarseOnly)
+                showPreciseUpgradeDialog()
+            }
+
             shouldShowRationale() -> {
                 onPermissionStateChanged(LocationPermissionState.RequiresRationale)
                 showPermissionRequiredDialog()
             }
-            
+
             else -> {
                 onPermissionStateChanged(LocationPermissionState.PermanentlyDenied)
                 showPermanentDenialDialog()
             }
         }
+    }
+
+    private fun showPreciseUpgradeDialog() {
+        // Ask once per session; re-requesting in a loop would just re-show the
+        // system dialog every time the fragment resumes
+        if (upgradeDialogShown) return
+        if (currentDialog?.isShowing == true) return
+        upgradeDialogShown = true
+
+        currentDialog = AlertDialog.Builder(fragment.requireContext())
+            .setTitle(fragment.getString(R.string.precise_location_required))
+            .setMessage(fragment.getString(R.string.precise_location_required_message))
+            .setPositiveButton(fragment.getString(R.string.grant_permission)) { _, _ ->
+                requestPermissions()
+            }
+            .setNegativeButton(fragment.getString(R.string.open_settings)) { _, _ ->
+                openAppSettings()
+            }
+            .setCancelable(false)
+            .create()
+
+        currentDialog?.show()
     }
     
     private fun showPermissionRequiredDialog() {

--- a/app/src/main/java/com/bizzarosn/heightmark/PressureDeltaDetector.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/PressureDeltaDetector.kt
@@ -1,0 +1,50 @@
+package com.bizzarosn.heightmark
+
+import kotlin.math.abs
+
+/**
+ * Detects vertical movement (elevator, escalator, stairs) from barometric
+ * pressure samples while the device is otherwise stationary.
+ *
+ * Pressure falls ~0.12 hPa per meter of ascent, so [thresholdHpa] of 0.3
+ * corresponds to roughly 2.5 m of elevation change. Two defenses against
+ * false wakes:
+ *  - the change must persist for [consecutiveSamples] samples, rejecting the
+ *    brief spikes HVAC systems and closing doors produce
+ *  - while quiet, the baseline slowly tracks the current pressure
+ *    ([baselineAlpha]), absorbing weather-front drift (~1 hPa/hour at worst)
+ */
+class PressureDeltaDetector(
+    private val thresholdHpa: Float = 0.3f,
+    private val consecutiveSamples: Int = 3,
+    private val baselineAlpha: Float = 0.01f,
+    private val smoothingAlpha: Float = 0.3f
+) {
+    private var baseline = Float.NaN
+    private var smoothed = Float.NaN
+    private var beyondCount = 0
+
+    /** Feeds one pressure sample in hPa. Returns true on sustained vertical movement. */
+    fun feed(pressureHpa: Float): Boolean {
+        if (baseline.isNaN()) {
+            baseline = pressureHpa
+            smoothed = pressureHpa
+            return false
+        }
+        smoothed += smoothingAlpha * (pressureHpa - smoothed)
+        if (abs(smoothed - baseline) > thresholdHpa) {
+            beyondCount++
+            if (beyondCount >= consecutiveSamples) return true
+        } else {
+            beyondCount = 0
+            baseline += baselineAlpha * (pressureHpa - baseline)
+        }
+        return false
+    }
+
+    fun reset() {
+        baseline = Float.NaN
+        smoothed = Float.NaN
+        beyondCount = 0
+    }
+}

--- a/app/src/main/java/com/bizzarosn/heightmark/StillnessDetector.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/StillnessDetector.kt
@@ -1,0 +1,54 @@
+package com.bizzarosn.heightmark
+
+import android.location.Location
+
+/**
+ * Decides from a stream of GNSS fixes whether the device has been stationary
+ * long enough to switch the GPS radio off.
+ *
+ * Stationary means: every fix in the last [windowMs] reports a speed below
+ * [maxSpeedMps] and stays within [maxDriftMeters] of the window's first fix.
+ * GNSS jitter makes exact-position checks useless, hence the drift allowance.
+ */
+class StillnessDetector(
+    private val windowMs: Long = 30_000L,
+    private val maxSpeedMps: Float = 0.5f,
+    private val maxDriftMeters: Float = 15f
+) {
+    private val window = ArrayDeque<Location>()
+
+    /**
+     * Feeds the next fix. Returns true once the device has been still for the
+     * full window; the caller is expected to stop feeding after that.
+     */
+    fun feed(location: Location): Boolean {
+        if (location.hasSpeed() && location.speed > maxSpeedMps) {
+            window.clear()
+            return false
+        }
+        window.addLast(location)
+
+        // Bound memory if the caller keeps feeding while already stationary
+        while (ageMs(window.first(), location) > 2 * windowMs) {
+            window.removeFirst()
+        }
+
+        val anchor = window.first()
+        if (ageMs(anchor, location) < windowMs) return false
+
+        if (window.any { anchor.distanceTo(it) > maxDriftMeters }) {
+            // Slow drift (e.g. walking pace below the speed threshold): restart
+            window.clear()
+            return false
+        }
+        return true
+    }
+
+    fun reset() {
+        window.clear()
+    }
+
+    private fun ageMs(older: Location, newer: Location): Long {
+        return (newer.elapsedRealtimeNanos - older.elapsedRealtimeNanos) / 1_000_000
+    }
+}

--- a/app/src/main/java/com/bizzarosn/heightmark/di/AppModule.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/di/AppModule.kt
@@ -1,9 +1,11 @@
 package com.bizzarosn.heightmark.di
 
 import android.content.Context
+import android.hardware.SensorManager
 import android.location.LocationManager
 import com.bizzarosn.heightmark.AltitudeResolver
 import com.bizzarosn.heightmark.ElevationService
+import com.bizzarosn.heightmark.IdleWakeMonitor
 import com.bizzarosn.heightmark.PreferencesRepository
 import dagger.Module
 import dagger.Provides
@@ -43,5 +45,21 @@ object AppModule {
         @ApplicationContext context: Context
     ): AltitudeResolver {
         return AltitudeResolver(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSensorManager(
+        @ApplicationContext context: Context
+    ): SensorManager {
+        return context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+    }
+
+    @Provides
+    fun provideIdleWakeMonitor(
+        locationManager: LocationManager,
+        sensorManager: SensorManager
+    ): IdleWakeMonitor {
+        return IdleWakeMonitor(locationManager, sensorManager)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,10 @@
     <string name="exit_app">Exit App</string>
     <string name="permission_permanently_denied_message">This app needs location permission to determine your elevation. Please open settings and enable location permission manually.</string>
     <string name="open_settings">Open Settings</string>
+    <string name="precise_location_required">Precise Location Required</string>
+    <string name="precise_location_required_message">Elevation comes from GPS, which needs precise location. Approximate location isn\'t enough. Please allow precise location.</string>
+    <string name="location_services_off">Location Is Off</string>
+    <string name="location_services_off_message">Turn on location to determine your elevation.</string>
+    <string name="open_location_settings">Open Location Settings</string>
+    <string name="still_searching">Still searching for GPS signal… This works best outdoors with a clear view of the sky.</string>
 </resources>

--- a/app/src/test/java/com/bizzarosn/heightmark/LocationPermissionHandlerUnitTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/LocationPermissionHandlerUnitTest.kt
@@ -32,6 +32,7 @@ class LocationPermissionHandlerUnitTest {
         val testState = LocationPermissionState.Denied
         val result = when (testState) {
             is LocationPermissionState.Granted -> "access granted"
+            is LocationPermissionState.CoarseOnly -> "coarse only"
             is LocationPermissionState.Denied -> "access denied"
             is LocationPermissionState.PermanentlyDenied -> "permanently denied"
             is LocationPermissionState.RequiresRationale -> "requires rationale"

--- a/app/src/test/java/com/bizzarosn/heightmark/PressureDeltaDetectorTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/PressureDeltaDetectorTest.kt
@@ -1,0 +1,60 @@
+package com.bizzarosn.heightmark
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PressureDeltaDetectorTest {
+
+    private val detector = PressureDeltaDetector()
+
+    @Test
+    fun `steady pressure never triggers`() {
+        repeat(100) {
+            assertFalse(detector.feed(1013.25f))
+        }
+    }
+
+    @Test
+    fun `sustained pressure drop triggers`() {
+        // ~4m of ascent: pressure drops 0.5 hPa and stays there
+        detector.feed(1000.0f)
+        var triggered = false
+        repeat(10) {
+            if (detector.feed(999.5f)) triggered = true
+        }
+        assertTrue("Elevator-scale sustained change should wake", triggered)
+    }
+
+    @Test
+    fun `brief spike from a closing door is rejected`() {
+        detector.feed(1000.0f)
+        // Single 2 hPa transient, then pressure recovers
+        assertFalse(detector.feed(998.0f))
+        var triggered = false
+        repeat(50) {
+            if (detector.feed(1000.0f)) triggered = true
+        }
+        assertFalse("Momentary spike must not wake", triggered)
+    }
+
+    @Test
+    fun `weather-front drift is absorbed by the baseline`() {
+        // 1 hPa/hour at 1 Hz sampling — the fastest realistic weather change
+        var pressure = 1010.0f
+        repeat(3600) {
+            assertFalse("Weather drift must not wake", detector.feed(pressure))
+            pressure -= 1f / 3600f
+        }
+    }
+
+    @Test
+    fun `reset requires a new baseline`() {
+        detector.feed(1000.0f)
+        repeat(3) { detector.feed(999.5f) }
+        detector.reset()
+        // First sample after reset only seeds the baseline
+        assertFalse(detector.feed(950.0f))
+        assertFalse(detector.feed(950.0f))
+    }
+}

--- a/app/src/test/java/com/bizzarosn/heightmark/StillnessDetectorTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/StillnessDetectorTest.kt
@@ -1,0 +1,67 @@
+package com.bizzarosn.heightmark
+
+import android.location.Location
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StillnessDetectorTest {
+
+    private val detector = StillnessDetector(
+        windowMs = 30_000L,
+        maxSpeedMps = 0.5f,
+        maxDriftMeters = 15f
+    )
+
+    private fun fix(atMs: Long, speed: Float = 0f, driftMeters: Float = 0f): Location {
+        val location = mockk<Location>()
+        every { location.elapsedRealtimeNanos } returns atMs * 1_000_000
+        every { location.hasSpeed() } returns true
+        every { location.speed } returns speed
+        // distanceTo is only ever called with the window anchor as receiver;
+        // model the anchor's drift parameter as its distance to everything
+        every { location.distanceTo(any()) } returns driftMeters
+        return location
+    }
+
+    @Test
+    fun `not stationary until the full window is covered`() {
+        assertFalse(detector.feed(fix(atMs = 0)))
+        assertFalse(detector.feed(fix(atMs = 10_000)))
+        assertFalse(detector.feed(fix(atMs = 20_000)))
+        assertTrue(detector.feed(fix(atMs = 30_000)))
+    }
+
+    @Test
+    fun `movement above speed threshold restarts the window`() {
+        assertFalse(detector.feed(fix(atMs = 0)))
+        assertFalse(detector.feed(fix(atMs = 15_000, speed = 2f)))
+        // Window restarted: 30s must elapse from the next still fix
+        assertFalse(detector.feed(fix(atMs = 20_000)))
+        assertFalse(detector.feed(fix(atMs = 45_000)))
+        assertTrue(detector.feed(fix(atMs = 50_000)))
+    }
+
+    @Test
+    fun `position drift beyond threshold restarts the window`() {
+        val anchor = fix(atMs = 0)
+        every { anchor.distanceTo(any()) } returns 20f
+        assertFalse(detector.feed(anchor))
+        assertFalse(detector.feed(fix(atMs = 31_000)))
+        // Drift detected relative to the anchor; window restarted
+        assertFalse(detector.feed(fix(atMs = 40_000)))
+        assertFalse(detector.feed(fix(atMs = 60_000)))
+        assertTrue(detector.feed(fix(atMs = 70_000)))
+    }
+
+    @Test
+    fun `reset clears accumulated stillness`() {
+        assertFalse(detector.feed(fix(atMs = 0)))
+        detector.reset()
+        assertFalse(detector.feed(fix(atMs = 30_000)))
+        assertFalse(detector.feed(fix(atMs = 59_000)))
+        assertTrue(detector.feed(fix(atMs = 60_000)))
+    }
+}


### PR DESCRIPTION
## Phase 3 of 4 — location API gap-filling plan (stacked on #194)

### What
GPS now duty-cycles: **continuous while moving, radio off while stationary**, waking automatically when movement resumes. Plus migration off the legacy `requestLocationUpdates(provider, minTime, minDistance, listener)` overload.

### How
- **`StillnessDetector`** (unit tested): stationary = 30 s of fixes with speed < 0.5 m/s clustered within 15 m (GNSS jitter allowance). On detection the fragment stops updates and freezes the displayed elevation.
- **`IdleWakeMonitor`**: while idle, arms every wake trigger the hardware offers, each skipped gracefully when absent:
  - `TYPE_SIGNIFICANT_MOTION` — horizontal movement. Its AOSP contract only covers walking/biking/vehicle travel, so…
  - **barometer** (`TYPE_PRESSURE` @ 1 Hz, ~2–3 µA) — catches **vertical** movement (elevators/escalators) via `PressureDeltaDetector` (unit tested): 0.3 hPa ≈ 2.5 m sustained over 3 samples, with a slow-tracking baseline that absorbs weather drift and a smoothing+persistence rule that rejects HVAC/door pressure transients.
  - passive provider — free fixes other apps request; wake if displaced > 30 m horizontally or > 10 m vertically from the idle anchor.
  - fallback `getCurrentLocation()` poll every 3 min, **only on devices with no barometer** — covers the elevator case on budget hardware.
- A false wake is cheap (GPS re-acquires, re-idles after 30 s of stillness); a missed wake self-heals via the passive/poll paths.
- **Modern request API**: `LocationRequest.Builder(1000).setQuality(QUALITY_HIGH_ACCURACY)` with the executor overload; deprecated `LocationListener` overrides deleted (default methods since API 30). Min-update-distance dropped to 0 so stillness detection keeps receiving fixes while parked.
- **Accuracy gate**: fixes with `verticalAccuracyMeters` > 50 m no longer enter the rolling average.

### Side benefit
While idle the Android 12+ location indicator turns off — visible confirmation the app isn't tracking while you sit still.

### Testing
9 new unit tests across the two detectors (window coverage, speed/drift restarts, sustained-change trigger, door-spike rejection, weather-drift absorption); all pass, lint clean, instrumented tests compile.