### PR TITLE
Fix UI contrast/accessibility issues and add automated a11y gates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,14 @@ android {
             it.maxParallelForks = Runtime.getRuntime().availableProcessors()
         }
     }
+    lint {
+        // Severities live in lint.xml, where the whole Accessibility category
+        // is promoted to error; abortOnError (the AGP default, made explicit)
+        // turns those findings into CI build failures.
+        abortOnError = true
+        xmlReport = true
+        htmlReport = true
+    }
 }
 
 dependencies {
@@ -109,6 +117,8 @@ dependencies {
     
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.espresso.accessibility)
+    androidTestImplementation(libs.accessibility.test.framework)
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.test.runner)
 

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <!-- "Accessibility" is a lint *category* id: every current accessibility
+         check — and any added in future AGP releases — fails the build
+         instead of warning. -->
+    <issue id="Accessibility" severity="error" />
+</lint>

--- a/app/src/androidTest/java/com/bizzarosn/heightmark/AccessibilityChecksTest.kt
+++ b/app/src/androidTest/java/com/bizzarosn/heightmark/AccessibilityChecksTest.kt
@@ -1,14 +1,17 @@
 package com.bizzarosn.heightmark
 
 import android.Manifest
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -20,6 +23,9 @@ import org.junit.runner.RunWith
  * hierarchy in each of them. Every perform() triggers a full-root-view pass:
  * touch target sizes, speakable text, screenshot-based text contrast,
  * duplicate descriptions, and whatever checks future framework versions add.
+ *
+ * Both themes are exercised: the day and night variants force their uiMode
+ * explicitly so coverage doesn't depend on the emulator's default.
  */
 @HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
@@ -39,13 +45,35 @@ class AccessibilityChecksTest {
         hiltRule.inject()
     }
 
+    @After
+    fun resetNightMode() {
+        setNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+    }
+
     @Test
-    fun allInteractiveStatesPassAccessibilityChecks() {
+    fun allInteractiveStatesPassAccessibilityChecks_day() {
+        setNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+        runAccessibilityPass()
+    }
+
+    @Test
+    fun allInteractiveStatesPassAccessibilityChecks_night() {
+        setNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+        runAccessibilityPass()
+    }
+
+    private fun runAccessibilityPass() {
         ActivityScenario.launch(MainActivity::class.java).use {
             onView(withId(R.id.button_feet)).perform(click())
             onView(withId(R.id.details_toggle)).perform(click()) // expand details
             onView(withId(R.id.details_toggle)).perform(click()) // collapse details
             onView(withId(R.id.button_meters)).perform(click()) // restore default unit
         }
+    }
+
+    private fun setNightMode(mode: Int) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync { AppCompatDelegate.setDefaultNightMode(mode) }
+        instrumentation.waitForIdleSync()
     }
 }

--- a/app/src/androidTest/java/com/bizzarosn/heightmark/AccessibilityChecksTest.kt
+++ b/app/src/androidTest/java/com/bizzarosn/heightmark/AccessibilityChecksTest.kt
@@ -1,0 +1,51 @@
+package com.bizzarosn.heightmark
+
+import android.Manifest
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Walks the screen through its interactive states so the Accessibility Test
+ * Framework checks (enabled globally in [HiltTestRunner]) validate the whole
+ * hierarchy in each of them. Every perform() triggers a full-root-view pass:
+ * touch target sizes, speakable text, screenshot-based text contrast,
+ * duplicate descriptions, and whatever checks future framework versions add.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class AccessibilityChecksTest {
+
+    @get:Rule(order = 0)
+    var hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val permissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        Manifest.permission.ACCESS_FINE_LOCATION,
+        Manifest.permission.ACCESS_COARSE_LOCATION
+    )
+
+    @Before
+    fun init() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun allInteractiveStatesPassAccessibilityChecks() {
+        ActivityScenario.launch(MainActivity::class.java).use {
+            onView(withId(R.id.button_feet)).perform(click())
+            onView(withId(R.id.details_toggle)).perform(click()) // expand details
+            onView(withId(R.id.details_toggle)).perform(click()) // collapse details
+            onView(withId(R.id.button_meters)).perform(click()) // restore default unit
+        }
+    }
+}

--- a/app/src/androidTest/java/com/bizzarosn/heightmark/HiltTestRunner.kt
+++ b/app/src/androidTest/java/com/bizzarosn/heightmark/HiltTestRunner.kt
@@ -2,10 +2,24 @@ package com.bizzarosn.heightmark
 
 import android.app.Application
 import android.content.Context
+import androidx.test.espresso.accessibility.AccessibilityChecks
 import androidx.test.runner.AndroidJUnitRunner
 import dagger.hilt.android.testing.HiltTestApplication
 
 class HiltTestRunner : AndroidJUnitRunner() {
+    init {
+        // Every Espresso ViewAction in the whole instrumented suite validates
+        // the full view hierarchy against Google's Accessibility Test
+        // Framework and fails the test on any ERROR finding (touch target
+        // size, missing speakable text, insufficient text contrast, ...).
+        // The validator runs the framework's LATEST check preset, so checks
+        // added in newer versions apply automatically as Dependabot bumps the
+        // dependency. Suppressions, if one is ever unavoidable, belong here
+        // via setSuppressingResultMatcher scoped to a single check + view.
+        AccessibilityChecks.enable()
+            .setRunChecksFromRootView(true)
+    }
+
     override fun newApplication(
         cl: ClassLoader?,
         className: String?,

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
@@ -17,7 +17,6 @@ import android.location.LocationManager
 import android.location.LocationRequest
 import android.os.Bundle
 import android.os.SystemClock
-import android.graphics.Color
 import android.provider.Settings
 import android.util.Log
 import android.util.TypedValue
@@ -163,6 +162,9 @@ class ElevationFragment : Fragment() {
         showDetails = show
         detailsPanel.isVisible = show
         detailsToggle.text = getString(if (show) R.string.details_hide else R.string.details_show)
+        detailsToggle.stateDescription = getString(
+            if (show) R.string.details_state_expanded else R.string.details_state_collapsed
+        )
         if (show) {
             startDetailsSources()
             refreshDetails()
@@ -566,6 +568,12 @@ class ElevationFragment : Fragment() {
     // Status messages use headline type; the hero display size is reserved for the value
     private fun showStatusText(text: String) {
         applyTextAppearance(com.google.android.material.R.attr.textAppearanceHeadlineSmall)
+        // Status sentences run long ("Still searching…") and must not clip
+        elevationTextView.maxLines = 3
+        // Errors and search-status changes are the moments a screen-reader
+        // user must hear unprompted; the ticking elevation number is not
+        elevationTextView.accessibilityLiveRegion = View.ACCESSIBILITY_LIVE_REGION_POLITE
+        elevationTextView.contentDescription = null
         elevationTextView.text = text
     }
 
@@ -573,7 +581,7 @@ class ElevationFragment : Fragment() {
         val resolved = TypedValue()
         requireContext().theme.resolveAttribute(textAppearanceAttr, resolved, true)
         TextViewCompat.setTextAppearance(elevationTextView, resolved.resourceId)
-        elevationTextView.setTextColor(Color.WHITE)
+        elevationTextView.setTextColor(requireContext().getColor(R.color.hm_on_scrim))
     }
 
     private fun updateUIWithElevation() {
@@ -589,10 +597,20 @@ class ElevationFragment : Fragment() {
         val meters = lastDisplayedElevationMeters ?: return
 
         applyTextAppearance(com.google.android.material.R.attr.textAppearanceDisplayLargeEmphasized)
+        elevationTextView.maxLines = 2
+        // The value refreshes ~every second while converging; a live region
+        // would make TalkBack announce every tick. Screen-reader users read
+        // the value on focus instead, with the unit spoken in full.
+        elevationTextView.accessibilityLiveRegion = View.ACCESSIBILITY_LIVE_REGION_NONE
         val localizedElevation = if (useMetricUnit) meters else UnitConverter.metersToFeet(meters)
         val elevationRounded = kotlin.math.round(localizedElevation).toInt()
         val unit = getString(if (useMetricUnit) R.string.unit_meters else R.string.unit_feet)
         elevationTextView.text = getString(R.string.elevation_text, elevationRounded, unit)
+        val spokenUnit = getString(
+            if (useMetricUnit) R.string.unit_meters_spoken else R.string.unit_feet_spoken
+        )
+        elevationTextView.contentDescription =
+            getString(R.string.elevation_a11y, elevationRounded, spokenUnit)
     }
 
     override fun onDestroy() {
@@ -607,6 +625,10 @@ class ElevationFragment : Fragment() {
         private const val UPDATE_INTERVAL_MS = 1_000L
         private const val MAX_VERTICAL_ACCURACY_M = 50f
         private const val RESET_AFTER_GAP_MS = 30_000L
-        private const val DIMMED_TEXT_ALPHA = 0.55f
+
+        // 0.7 keeps the dimmed (large-text) hero >= 3:1 over the scrim floor
+        // in day mode; verified by ScrimContrastTest, which references this
+        // constant directly.
+        internal const val DIMMED_TEXT_ALPHA = 0.7f
     }
 }

--- a/app/src/main/java/com/bizzarosn/heightmark/StabilityLineView.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/StabilityLineView.kt
@@ -86,8 +86,13 @@ class StabilityLineView @JvmOverloads constructor(
     private var state: ReadingState = ReadingState.Acquiring
     private var animator: ValueAnimator? = null
 
+    init {
+        // The initial state never passes through setState's change guard
+        stateDescription = context.getString(spokenStateRes(state))
+    }
+
     fun setState(newState: ReadingState) {
-        if (newState == state && contentDescription != null) return
+        if (newState == state) return
         state = newState
         when (newState) {
             ReadingState.Acquiring -> setTargets(amplitude = 1f, core = 0f, dormantMix = 0f)
@@ -98,20 +103,28 @@ class StabilityLineView @JvmOverloads constructor(
             ReadingState.Stable -> setTargets(amplitude = 0f, core = 1f, dormantMix = 0f)
             ReadingState.Dormant -> setTargets(amplitude = 0f, core = 0f, dormantMix = 1f)
         }
-        contentDescription = context.getString(
-            when (newState) {
-                ReadingState.Acquiring -> R.string.stability_acquiring
-                is ReadingState.Converging -> R.string.stability_converging
-                ReadingState.Stable -> R.string.stability_stable
-                ReadingState.Dormant -> R.string.stability_dormant
-            }
-        )
+        // The static contentDescription comes from the layout; the state
+        // rides in stateDescription, whose change event the polite live
+        // region turns into an automatic TalkBack announcement. Converging
+        // arrives once per progress step, so guard against re-announcing
+        // the same phrase.
+        val spokenState = context.getString(spokenStateRes(newState))
+        if (stateDescription != spokenState) {
+            stateDescription = spokenState
+        }
         if (!ValueAnimator.areAnimatorsEnabled()) {
             snapToTargets()
         } else if (isAttachedToWindow) {
             startAnimator()
         }
         invalidate()
+    }
+
+    private fun spokenStateRes(state: ReadingState) = when (state) {
+        ReadingState.Acquiring -> R.string.stability_acquiring
+        is ReadingState.Converging -> R.string.stability_converging
+        ReadingState.Stable -> R.string.stability_stable
+        ReadingState.Dormant -> R.string.stability_dormant
     }
 
     private fun setTargets(amplitude: Float, core: Float, dormantMix: Float) {
@@ -242,9 +255,14 @@ class StabilityLineView @JvmOverloads constructor(
         private const val EPSILON = 0.005f
         private const val WAVE_PERIOD_MS = 1_400L
         private const val BREATH_PERIOD_MS = 4_000L
-        private const val WAVE_ALPHA = 0.55f
-        private const val CORE_ALPHA = 0.95f
+        // The wave and dormant strokes carry meaning, so they must clear the
+        // 3:1 non-text contrast minimum over the day-mode scrim floor;
+        // ScrimContrastTest references these constants directly. The glow is
+        // a decorative under-stroke beneath the near-opaque core line and is
+        // exempt.
+        internal const val WAVE_ALPHA = 0.65f
+        internal const val CORE_ALPHA = 0.95f
         private const val GLOW_ALPHA = 0.22f
-        private const val DORMANT_ALPHA = 0.35f
+        internal const val DORMANT_ALPHA = 0.6f
     }
 }

--- a/app/src/main/res/drawable/bg_bottom_scrim.xml
+++ b/app/src/main/res/drawable/bg_bottom_scrim.xml
@@ -1,8 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <gradient
-        android:angle="90"
-        android:startColor="@color/hm_scrim_overlay"
-        android:centerColor="#66000000"
-        android:endColor="@android:color/transparent" />
-</shape>
+<!-- Text-protection scrim. The fade to transparent lives entirely inside
+     content_container's 48dp top padding band, so every text element sits on
+     at least hm_scrim_floor (60% black) — white text stays >= 4.5:1 even over
+     the palest part of the day illustration. -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:gravity="top" android:height="48dp">
+        <shape>
+            <gradient
+                android:angle="90"
+                android:startColor="@color/hm_scrim_floor"
+                android:endColor="@android:color/transparent" />
+        </shape>
+    </item>
+    <item android:top="48dp">
+        <shape>
+            <gradient
+                android:angle="90"
+                android:startColor="@color/hm_scrim_overlay"
+                android:endColor="@color/hm_scrim_floor" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/fragment_elevation.xml
+++ b/app/src/main/res/layout/fragment_elevation.xml
@@ -39,7 +39,7 @@
             android:layout_height="wrap_content"
             android:text="@string/current_elevation"
             android:textAppearance="?attr/textAppearanceLabelLargeEmphasized"
-            android:textColor="#CCFFFFFF" />
+            android:textColor="@color/hm_on_scrim_secondary" />
 
         <TextView
             android:id="@+id/elevation_text_view"
@@ -49,13 +49,15 @@
             android:maxLines="2"
             android:text="@string/loading_elevation"
             android:textAppearance="?attr/textAppearanceHeadlineSmall"
-            android:textColor="@android:color/white" />
+            android:textColor="@color/hm_on_scrim" />
 
         <com.bizzarosn.heightmark.StabilityLineView
             android:id="@+id/stability_line"
             android:layout_width="200dp"
             android:layout_height="24dp"
-            android:layout_marginTop="2dp" />
+            android:layout_marginTop="2dp"
+            android:accessibilityLiveRegion="polite"
+            android:contentDescription="@string/stability_line_a11y" />
 
         <com.google.android.material.button.MaterialButtonToggleGroup
             android:id="@+id/unit_toggle_group"
@@ -71,6 +73,8 @@
                 style="?attr/materialButtonOutlinedStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/unit_meters_a11y"
+                android:minHeight="48dp"
                 android:minWidth="96dp"
                 android:text="@string/unit_meters" />
 
@@ -79,6 +83,8 @@
                 style="?attr/materialButtonOutlinedStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/unit_feet_a11y"
+                android:minHeight="48dp"
                 android:minWidth="96dp"
                 android:text="@string/unit_feet" />
         </com.google.android.material.button.MaterialButtonToggleGroup>
@@ -89,9 +95,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
+            android:minHeight="48dp"
+            android:minWidth="48dp"
             android:text="@string/details_show"
-            android:textColor="#CCFFFFFF"
-            app:iconTint="#CCFFFFFF" />
+            android:textColor="@color/hm_on_scrim_secondary" />
 
         <TextView
             android:id="@+id/details_panel"
@@ -100,7 +107,7 @@
             android:layout_marginTop="4dp"
             android:fontFamily="monospace"
             android:textAppearance="?attr/textAppearanceBodySmall"
-            android:textColor="#CCFFFFFF"
+            android:textColor="@color/hm_on_scrim_secondary"
             android:visibility="gone"
             tools:text="Sea-level elevation: 112.4 m"
             tools:visibility="visible" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -16,4 +16,16 @@
 
     <color name="hm_splash_background">#F7FBF1</color>
     <color name="hm_scrim_overlay">#B3000000</color>
+    <!-- Minimum scrim darkness behind any on-image text. 60% black over the
+         palest region of the day illustration (#F0F9F2) composites to a
+         backdrop against which white text measures ~6:1 and 90% white ~5.3:1,
+         both clearing the WCAG 1.4.3 AA threshold of 4.5:1.
+         ScrimContrastTest verifies this relationship. -->
+    <color name="hm_scrim_floor">#99000000</color>
+
+    <!-- Text/stroke colors used on top of the scrimmed background image.
+         Referenced by both the layout and ScrimContrastTest. -->
+    <color name="hm_on_scrim">#FFFFFFFF</color>
+    <color name="hm_on_scrim_secondary">#E6FFFFFF</color>
+    <color name="hm_on_scrim_outline">#B3FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,16 @@
     <string name="current_elevation">Current elevation</string>
     <string name="unit_meters">m</string>
     <string name="unit_feet">ft</string>
+    <!-- Screen-reader labels: the visual chips show bare "m"/"ft", which
+         TalkBack would read letter-by-letter -->
+    <string name="unit_meters_a11y">Meters</string>
+    <string name="unit_feet_a11y">Feet</string>
+    <string name="unit_meters_spoken">meters</string>
+    <string name="unit_feet_spoken">feet</string>
+    <string name="elevation_a11y">%1$d %2$s</string>
+    <string name="stability_line_a11y">Reading stability</string>
+    <string name="details_state_expanded">Expanded</string>
+    <string name="details_state_collapsed">Collapsed</string>
     <string name="location_permission_required">Location Permission Required</string>
     <string name="this_app_needs_location_permission_to_determine_your_elevation_without_this_permission_the_app_cannot_function">This app needs location permission to determine your elevation. Without this permission, the app cannot function.</string>
     <string name="grant_permission">Grant Permission</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -18,11 +18,15 @@
 
     <style name="Theme.HeightMark" parent="Base.Theme.HeightMark" />
 
-    <!-- For controls sitting on top of the photo/scrim: white text and outline
-         regardless of light/dark theme, while checked containers keep theme colors. -->
+    <!-- For controls sitting on top of the photo/scrim: every color is pinned
+         (opting out of dynamic color) because the backdrop is the always-dark
+         scrim in both light and dark themes. The checked-container pair is the
+         light-scheme secondary container: ~13:1 label-on-container contrast. -->
     <style name="ThemeOverlay.HeightMark.OnImage" parent="">
-        <item name="colorOnSurface">@android:color/white</item>
-        <item name="colorOutline">#B3FFFFFF</item>
+        <item name="colorOnSurface">@color/hm_on_scrim</item>
+        <item name="colorOutline">@color/hm_on_scrim_outline</item>
+        <item name="colorSecondaryContainer">#D4E8D0</item>
+        <item name="colorOnSecondaryContainer">#0F1F10</item>
     </style>
 
     <style name="Theme.HeightMark.Splash" parent="Theme.SplashScreen">

--- a/app/src/test/java/com/bizzarosn/heightmark/ScrimContrastTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/ScrimContrastTest.kt
@@ -1,0 +1,126 @@
+package com.bizzarosn.heightmark
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+
+/**
+ * WCAG 2.1 contrast regression test for everything drawn over the background
+ * illustration.
+ *
+ * The runtime accessibility checks (ATF via the test runner) measure contrast
+ * on emulator screenshots, but nothing there pins the *worst case*: the palest
+ * region of the day illustration under the thinnest part of the scrim. This
+ * test does that with pure math, so "lighten the scrim a touch" or "dim the
+ * text a bit more" fails fast on the JVM with the computed ratio in the
+ * message.
+ *
+ * Color values are parsed from the resource files and alpha constants are
+ * referenced from production code — the only test-local constant is the
+ * measured backdrop swatch.
+ */
+class ScrimContrastTest {
+
+    /**
+     * Palest color in the lower third of drawable-nodpi/background.webp (the
+     * day illustration's mist band, where the scrim is thinnest relative to
+     * the artwork). Manual step: re-measure this swatch if the day artwork
+     * ever changes.
+     */
+    private val worstCaseDayBackdrop = Rgb(0xF0 / 255.0, 0xF9 / 255.0, 0xF2 / 255.0)
+
+    /** Backdrop every on-image element sits on: the scrim floor over the pale artwork. */
+    private val scrimmedBackdrop = resourceColor("hm_scrim_floor").over(worstCaseDayBackdrop)
+
+    private val white = resourceColor("hm_on_scrim").over(scrimmedBackdrop)
+
+    @Test
+    fun `primary on-scrim text meets 4_5 to 1`() {
+        assertAtLeast(4.5, contrast(white, scrimmedBackdrop), "hm_on_scrim text")
+    }
+
+    @Test
+    fun `secondary on-scrim text meets 4_5 to 1`() {
+        val secondary = resourceColor("hm_on_scrim_secondary").over(scrimmedBackdrop)
+        assertAtLeast(4.5, contrast(secondary, scrimmedBackdrop), "hm_on_scrim_secondary text")
+    }
+
+    @Test
+    fun `unit chip outline meets non-text 3 to 1`() {
+        val outline = resourceColor("hm_on_scrim_outline").over(scrimmedBackdrop)
+        assertAtLeast(3.0, contrast(outline, scrimmedBackdrop), "hm_on_scrim_outline stroke")
+    }
+
+    @Test
+    fun `dormant-dimmed hero number meets large-text 3 to 1`() {
+        val dimmed = whiteAtAlpha(ElevationFragment.DIMMED_TEXT_ALPHA)
+        assertAtLeast(3.0, contrast(dimmed, scrimmedBackdrop), "hero at DIMMED_TEXT_ALPHA")
+    }
+
+    @Test
+    fun `stability line strokes meet non-text 3 to 1`() {
+        val wave = whiteAtAlpha(StabilityLineView.WAVE_ALPHA)
+        val core = whiteAtAlpha(StabilityLineView.CORE_ALPHA)
+        val dormant = whiteAtAlpha(StabilityLineView.DORMANT_ALPHA)
+        assertAtLeast(3.0, contrast(wave, scrimmedBackdrop), "wave at WAVE_ALPHA")
+        assertAtLeast(3.0, contrast(core, scrimmedBackdrop), "core at CORE_ALPHA")
+        assertAtLeast(3.0, contrast(dormant, scrimmedBackdrop), "dormant line at DORMANT_ALPHA")
+    }
+
+    // ---- WCAG math ----------------------------------------------------------
+
+    private data class Rgb(val r: Double, val g: Double, val b: Double)
+
+    private data class Argb(val a: Double, val rgb: Rgb) {
+        /** Source-over composite onto an opaque backdrop. */
+        fun over(dst: Rgb) = Rgb(
+            rgb.r * a + dst.r * (1 - a),
+            rgb.g * a + dst.g * (1 - a),
+            rgb.b * a + dst.b * (1 - a)
+        )
+    }
+
+    private fun whiteAtAlpha(alpha: Float) =
+        Argb(alpha.toDouble(), Rgb(1.0, 1.0, 1.0)).over(scrimmedBackdrop)
+
+    private fun relativeLuminance(c: Rgb): Double {
+        fun linear(v: Double) = if (v <= 0.03928) v / 12.92 else ((v + 0.055) / 1.055).pow(2.4)
+        return 0.2126 * linear(c.r) + 0.7152 * linear(c.g) + 0.0722 * linear(c.b)
+    }
+
+    private fun contrast(a: Rgb, b: Rgb): Double {
+        val la = relativeLuminance(a)
+        val lb = relativeLuminance(b)
+        return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+    }
+
+    private fun assertAtLeast(threshold: Double, ratio: Double, subject: String) {
+        assertTrue(
+            "$subject contrast is %.2f:1 over the day-mode worst case; WCAG requires $threshold:1"
+                .format(ratio),
+            ratio >= threshold
+        )
+    }
+
+    // ---- Resource parsing ---------------------------------------------------
+
+    private fun resourceColor(name: String): Argb {
+        // Unit tests run with the module directory as the working directory
+        val xml = File("src/main/res/values/colors.xml").readText()
+        val hex = Regex("""<color name="$name">#([0-9A-Fa-f]{6,8})</color>""")
+            .find(xml)?.groupValues?.get(1)
+            ?: error("Color resource '$name' not found in colors.xml")
+        val argb = hex.padStart(8, 'F').toLong(16)
+        return Argb(
+            a = ((argb shr 24) and 0xFF) / 255.0,
+            rgb = Rgb(
+                ((argb shr 16) and 0xFF) / 255.0,
+                ((argb shr 8) and 0xFF) / 255.0,
+                (argb and 0xFF) / 255.0
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/bizzarosn/heightmark/ScrimContrastTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/ScrimContrastTest.kt
@@ -12,28 +12,26 @@ import kotlin.math.pow
  * illustration.
  *
  * The runtime accessibility checks (ATF via the test runner) measure contrast
- * on emulator screenshots, but nothing there pins the *worst case*: the palest
- * region of the day illustration under the thinnest part of the scrim. This
- * test does that with pure math, so "lighten the scrim a touch" or "dim the
- * text a bit more" fails fast on the JVM with the computed ratio in the
- * message.
+ * on emulator screenshots, but nothing there pins the *worst case*. This test
+ * does it with pure math, so "lighten the scrim a touch" or "dim the text a
+ * bit more" fails fast on the JVM with the computed ratio in the message.
  *
  * Color values are parsed from the resource files and alpha constants are
- * referenced from production code — the only test-local constant is the
- * measured backdrop swatch.
+ * referenced from production code.
  */
 class ScrimContrastTest {
 
     /**
-     * Palest color in the lower third of drawable-nodpi/background.webp (the
-     * day illustration's mist band, where the scrim is thinnest relative to
-     * the artwork). Manual step: re-measure this swatch if the day artwork
-     * ever changes.
+     * Pure white: the brightest backdrop any artwork can produce beneath the
+     * scrim. Both illustrations really do reach it (the day mist band and the
+     * night horizon glow), and using the absolute bound makes these
+     * guarantees hold for BOTH themes and for any future artwork swap —
+     * nothing needs re-measuring when the images change.
      */
-    private val worstCaseDayBackdrop = Rgb(0xF0 / 255.0, 0xF9 / 255.0, 0xF2 / 255.0)
+    private val worstCaseBackdrop = Rgb(1.0, 1.0, 1.0)
 
-    /** Backdrop every on-image element sits on: the scrim floor over the pale artwork. */
-    private val scrimmedBackdrop = resourceColor("hm_scrim_floor").over(worstCaseDayBackdrop)
+    /** Backdrop every on-image element sits on: the scrim floor over the artwork. */
+    private val scrimmedBackdrop = resourceColor("hm_scrim_floor").over(worstCaseBackdrop)
 
     private val white = resourceColor("hm_on_scrim").over(scrimmedBackdrop)
 
@@ -99,7 +97,7 @@ class ScrimContrastTest {
 
     private fun assertAtLeast(threshold: Double, ratio: Double, subject: String) {
         assertTrue(
-            "$subject contrast is %.2f:1 over the day-mode worst case; WCAG requires $threshold:1"
+            "$subject contrast is %.2f:1 over the worst-case (pure white) backdrop; WCAG requires $threshold:1"
                 .format(ratio),
             ratio >= threshold
         )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ ksp = "2.3.10"
 mockk = "1.14.11"
 coroutinesTest = "1.11.0"
 coreSplashscreen = "1.2.0"
+accessibilityTestFramework = "4.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -25,6 +26,10 @@ androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscree
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-espresso-accessibility = { group = "androidx.test.espresso", name = "espresso-accessibility", version.ref = "espressoCore" }
+# Explicit pin of Google's Accessibility Test Framework so Dependabot bumps it
+# directly; its LATEST check preset means new checks apply automatically.
+accessibility-test-framework = { group = "com.google.android.apps.common.testing.accessibility.framework", name = "accessibility-test-framework", version.ref = "accessibilityTestFramework" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }


### PR DESCRIPTION
## Summary

An accessibility audit of the elevation screen found WCAG failures in **both themes** and screen-reader gaps; this PR fixes them and adds three layers of automated gating so regressions — and *new* checks as the frameworks evolve — are caught in CI.

### Audit findings
- **Contrast:** white/80%-white text sat on the transparent top of the bottom scrim, directly over the artwork. In day mode the pale lower third measured ≈1.4:1 for the "Current elevation" label and ≈1.5–2.4:1 for the hero number (vs the 4.5:1 WCAG AA minimum). Night mode was **worse where it mattered**: the night illustration's horizon glow contains pure-white pixels in the text band, bottoming out at 1:1. Chip outline and dimmed/dormant strokes were at or below the 3:1 non-text minimum.
- **Screen readers:** no announcements anywhere (reading-state changes, unit switches, and elevation updates were silent); stability line had no description at inflation; unit chips read as bare letters "m"/"ft"; details toggle had no expanded/collapsed semantics.
- **Touch targets:** unit chips and details toggle had no 48dp minimum height.
- **Text clipping:** the 90-char "Still searching…" status clipped at `maxLines=2`.

### Production fixes
- Rebuilt `bg_bottom_scrim` as a layer-list with a **60% black floor** behind all content; the fade to transparent now lives inside the container's 48dp top padding. The floor makes contrast **artwork-independent**: even over pure white — the brightest backdrop any image can produce — white text measures 5.74:1. The visual design is otherwise unchanged.
- On-image text colors promoted to named resources (`hm_on_scrim*`); secondary text raised from 80% → 90% white (~5.0:1 at the worst-case bound).
- Dimmed hero 0.55 → 0.7 alpha, stability-line wave 0.55 → 0.65, dormant 0.35 → 0.6 — all now clear 3:1 at the worst-case bound while staying visibly distinct.
- Reading-state transitions announced via `stateDescription` + polite live region on the stability line; status text is a polite live region; the hero speaks "1234 meters" on focus (deliberately not announced per one-second tick); chips labeled "Meters"/"Feet" with 48dp targets; details toggle exposes Expanded/Collapsed; status text allows 3 lines.
- `ThemeOverlay.HeightMark.OnImage` pins the checked-chip container colors so chips render identically over the always-dark scrim in both themes.

### Automated gates
1. **ATF via Espresso** — `AccessibilityChecks.enable().setRunChecksFromRootView(true)` in the shared `HiltTestRunner`: every ViewAction in the instrumented suite validates the full hierarchy (touch targets, speakable text, screenshot-based contrast, …). The validator runs ATF's `LATEST` preset, so Dependabot bumps bring new checks in automatically. `AccessibilityChecksTest` walks the screen's interactive states **in both explicitly forced day and night uiModes**.
2. **Lint** — `app/lint.xml` promotes the whole **Accessibility category** to error severity (covers future lint checks too); `abortOnError` makes it a hard gate in the existing `lintDebug` CI step.
3. **`ScrimContrastTest`** (JVM) — WCAG contrast math over the parsed color resources and production alpha constants, asserted against a **pure-white worst-case backdrop**. Because that bound is artwork-independent, the guarantee holds for both themes and survives any future artwork swap with nothing to re-measure.

### Deliberately not automated
- TalkBack spoken UX and Accessibility Scanner walkthrough — manual checklist; ATF verifies the underlying semantics exist.
- Edge-to-edge insets and the single-item bottom nav were reviewed and intentionally left unchanged.

## Test plan
- [x] `lintDebug` passes with the Accessibility category at error severity
- [x] `testDebugUnitTest` passes, including the new `ScrimContrastTest`
- [x] `connectedDebugAndroidTest` passes on the API 35 emulator with ATF checks enabled suite-wide, in day and night modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD3GAM8YtsA8ZDhQGiyZeP