### PR TITLE
build: clear all build warnings and AGP 9 deprecations

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -80,8 +80,10 @@ jobs:
       - name: Run lint, tests, and build in parallel
         id: build
         run: |
-          # Run lint and unit tests in parallel, then build
-          ./gradlew lintDebug testDebugUnitTest assembleDebug --parallel --build-cache
+          # assembleRelease is the PR gate on R8 and resource shrinking, which no
+          # debug task exercises. This job has no signing secrets, so the release
+          # APK it produces is unsigned and is never uploaded.
+          ./gradlew lintDebug testDebugUnitTest assembleDebug assembleRelease --parallel --build-cache
           echo "apk-path=app/build/outputs/apk/debug/*.apk" >> $GITHUB_OUTPUT
         
       - name: Publish Unit Test Results

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,8 @@ The app uses **Hilt**. **AppModule** (`di/AppModule.kt`, `SingletonComponent`) p
 ## Key Technical Details
 
 - **Compile SDK**: 37, **Target SDK**: 36, **Minimum SDK**: 34 (Android 14)
-- **Toolchain**: Kotlin 2.4.10, AGP 9.3.1, Gradle wrapper 9.6.1, JDK 21 (Temurin), Java/Kotlin target 17
+- **Toolchain**: AGP 9.3.1, Gradle wrapper 9.6.1, JDK 21 (Temurin), Java/Kotlin target 17
+- **Kotlin**: compiled through AGP's **built-in Kotlin support** — there is no `org.jetbrains.kotlin.android` plugin and no `kotlin` version in the catalog, so the Kotlin version is whatever KGP the AGP version bundles (2.2.10 for AGP 9.3.1) and moves with AGP. Do not re-add the plugin or the `android.builtInKotlin` / `android.newDsl` opt-outs: applying the standalone plugin makes it call the legacy variant API, and every one of those calls is a deprecation that AGP 10 removes outright. `ksp` is still pinned in the catalog and is bumped by Dependabot independently.
 - **JDK selection**: the Gradle daemon JVM is pinned by Daemon JVM criteria in `gradle/gradle-daemon-jvm.properties` (`toolchainVendor=ADOPTIUM`, `toolchainVersion=21`), so IDE, CLI, and CI builds all run on Temurin 21. `.tool-versions` pins the local install, and CI's three `setup-java` steps must keep `distribution: 'temurin'` to satisfy the vendor pin. Do **not** repin the vendor to `JETBRAINS` — Android Studio's bundled JBR lives inside the app bundle, which Gradle's toolchain auto-detection does not scan, so that pin forces a JDK download on every machine and every CI job. Android Studio still *boots* on its bundled JBR through a separate mechanism (`STUDIO_JDK` / the `jbr` directory); the criteria file has no effect on the IDE runtime. Dependabot bumps none of `toolchainVersion`, `.tool-versions`, or `setup-java`'s `java-version` — move those three by hand, together.
 - **Dependency Injection**: Hilt 2.60.1 with KSP 2.3.10
 - **Architecture Components**: Navigation Component, DataStore Preferences
@@ -140,7 +141,7 @@ All instrumented tests use `@HiltAndroidTest` + `HiltAndroidRule`; rule ordering
 Triggers on push to `main` and on all PRs (deliberately no base-branch filter, to support stacked PRs). Three jobs:
 
 1. **security**: Trivy filesystem scan → SARIF upload (runs immediately, parallel with build)
-2. **build-and-test**: single job running `lintDebug testDebugUnitTest assembleDebug` (combined to avoid per-job setup overhead); publishes test results and lint annotations to the PR; uploads the debug APK; Gradle cache write access
+2. **build-and-test**: single job running `lintDebug testDebugUnitTest assembleDebug assembleRelease` (combined to avoid per-job setup overhead); publishes test results and lint annotations to the PR; uploads the debug APK; Gradle cache write access. `assembleRelease` is there so R8 and resource shrinking are exercised on every PR rather than first running in `release.yml`; without signing secrets it produces an unsigned APK that is built but never uploaded
 3. **instrumented-tests** (needs build-and-test): emulator tests on API 35 (google_apis, x86_64) with KVM, AVD snapshot caching, and read-only Gradle cache (avoids conflicts with job 2)
 
 Gradle performance flags (parallel, build cache, `workers.max=4`, configuration cache, no incremental Kotlin) are set via `GRADLE_OPTS` in the workflow — the configuration cache is CI-only and only in `android_build.yml`, not `release.yml`.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.androidApplication)
-    alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.hiltAndroid)
     alias(libs.plugins.ksp)
 }
@@ -89,8 +88,6 @@ android {
         // is promoted to error; abortOnError (the AGP default, made explicit)
         // turns those findings into CI build failures.
         abortOnError = true
-        xmlReport = true
-        htmlReport = true
     }
 }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -12,21 +12,14 @@
 #   public *;
 #}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
--keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
+# Attributes that keep release stack traces readable, while still obfuscating
+# the original source file name.
+-keepattributes Exceptions,InnerClasses,Signature,Deprecated,SourceFile,LineNumberTable,*Annotation*,EnclosingMethod
 -renamesourcefileattribute SourceFile
 
-# Keep crash reporting attributes
--keepattributes Exceptions,InnerClasses,Signature,Deprecated,SourceFile,LineNumberTable,*Annotation*,EnclosingMethod
-
-# Keep all classes that might be referenced by navigation component
--keep class androidx.navigation.** { *; }
--keep class com.bizzarosn.heightmark.** { *; }
-
-# Keep location and sensor related classes
--keep class android.location.** { *; }
--keep class android.hardware.** { *; }
+# The app needs no keep rules of its own: it uses no reflection or dynamic class
+# loading, Hilt and Navigation ship consumer rules, and AGP generates keep rules
+# for the classes named in the manifest and in XML resources (ElevationFragment,
+# StabilityLineView). Keep anything added here narrow — a package-wide
+# `-keep class com.bizzarosn.heightmark.** { *; }` opts the entire app out of
+# minification, which costs ~450 KB in the release APK.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,10 +4,13 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
-    <!-- Elevation comes from GNSS; the app is useless without it -->
+    <!-- Elevation comes from GNSS; the app is useless without it. required="true"
+         is load-bearing: it filters the app off GPS-less devices in the Play
+         Store, so UnnecessaryRequiredFeature does not apply here. -->
     <uses-feature
         android:name="android.hardware.location.gps"
-        android:required="true" />
+        android:required="true"
+        tools:ignore="UnnecessaryRequiredFeature" />
 
     <application
         android:name=".HeightMarkApplication"

--- a/app/src/main/java/com/bizzarosn/heightmark/LengthFormatter.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/LengthFormatter.kt
@@ -12,7 +12,7 @@ import kotlin.math.round
 object LengthFormatter {
 
     /** Template + formatted value for a detail row ("112.4 m" / "369 ft"). */
-    data class Detail(@StringRes val templateRes: Int, val valueText: String)
+    data class Detail(@param:StringRes val templateRes: Int, val valueText: String)
 
     fun detail(meters: Double, useMetric: Boolean, locale: Locale): Detail {
         return if (useMetric) {

--- a/app/src/main/java/com/bizzarosn/heightmark/StabilityLineView.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/StabilityLineView.kt
@@ -10,6 +10,7 @@ import android.graphics.Path
 import android.util.AttributeSet
 import android.view.View
 import androidx.annotation.StringRes
+import androidx.core.graphics.withSave
 import android.view.animation.AnimationUtils
 import android.view.animation.LinearInterpolator
 import kotlin.math.PI
@@ -103,7 +104,7 @@ class StabilityLineView @JvmOverloads constructor(
         val amplitude: Float,
         val core: Float,
         val dormantMix: Float,
-        @StringRes val spokenRes: Int
+        @param:StringRes val spokenRes: Int
     )
 
     private fun presentationFor(state: ReadingState): StatePresentation = when (state) {
@@ -198,12 +199,12 @@ class StabilityLineView @JvmOverloads constructor(
                 buildWavePath(inset, width - inset, centerY)
                 wavePaint.setAlphaFraction(WAVE_ALPHA * active)
                 if (coreHalf > 0f) {
-                    canvas.save()
-                    canvas.clipOutRect(
-                        centerX - coreHalf, 0f, centerX + coreHalf, height.toFloat()
-                    )
-                    canvas.drawPath(wavePath, wavePaint)
-                    canvas.restore()
+                    canvas.withSave {
+                        clipOutRect(
+                            centerX - coreHalf, 0f, centerX + coreHalf, height.toFloat()
+                        )
+                        drawPath(wavePath, wavePaint)
+                    }
                 } else {
                     canvas.drawPath(wavePath, wavePaint)
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">HeightMark</string>
     <string name="elevation_text">%1$d %2$s</string>
     <string name="loading_elevation">Fetching elevation…</string>
@@ -40,7 +40,9 @@
     <string name="detail_ellipsoid">Ellipsoid altitude: %1$s</string>
     <string name="detail_geoid_offset">Geoid offset: %1$s</string>
     <string name="detail_accuracy">Accuracy: ±%1$s vertical · ±%2$s horizontal</string>
-    <string name="detail_satellites">Satellites: %1$d used / %2$d visible</string>
+    <!-- Two independent counts. A <plurals> resource selects on a single
+         quantity, so this cannot be expressed as one. -->
+    <string name="detail_satellites" tools:ignore="PluralsCandidate">Satellites: %1$d used / %2$d visible</string>
     <string name="detail_position">Position: %1$s, %2$s</string>
     <string name="detail_fix_age">Last fix: %1$ds ago</string>
     <string name="detail_readings">Readings in average: %1$d</string>

--- a/app/src/test/java/com/bizzarosn/heightmark/LocationPermissionHandlerUnitTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/LocationPermissionHandlerUnitTest.kt
@@ -8,17 +8,12 @@ class LocationPermissionHandlerUnitTest {
 
     @Test
     fun `permission state objects are correctly typed`() {
-        // Verify sealed class hierarchy and object equality
-        val granted = LocationPermissionState.Granted
-        val coarseOnly = LocationPermissionState.CoarseOnly
-        val permanentlyDenied = LocationPermissionState.PermanentlyDenied
-        val requiresRationale = LocationPermissionState.RequiresRationale
-
-        // Verify all are instances of the sealed class
-        assertTrue("Granted should be LocationPermissionState", granted is LocationPermissionState)
-        assertTrue("CoarseOnly should be LocationPermissionState", coarseOnly is LocationPermissionState)
-        assertTrue("PermanentlyDenied should be LocationPermissionState", permanentlyDenied is LocationPermissionState)
-        assertTrue("RequiresRationale should be LocationPermissionState", requiresRationale is LocationPermissionState)
+        // The explicit supertype is the assertion: if a state ever leaves the
+        // sealed hierarchy, these declarations stop compiling.
+        val granted: LocationPermissionState = LocationPermissionState.Granted
+        val coarseOnly: LocationPermissionState = LocationPermissionState.CoarseOnly
+        val permanentlyDenied: LocationPermissionState = LocationPermissionState.PermanentlyDenied
+        val requiresRationale: LocationPermissionState = LocationPermissionState.RequiresRationale
 
         // Verify different states are not equal
         assertNotEquals("Different states should not be equal", granted, coarseOnly)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.androidApplication) apply false
-    alias(libs.plugins.jetbrainsKotlinAndroid) apply false
     alias(libs.plugins.hiltAndroid) apply false
     alias(libs.plugins.ksp) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,11 +25,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-# Remaining AGP 9 legacy-behavior opt-outs, deferred deliberately:
-# the R8 flags change release-build behavior that PR CI never exercises
-# (only release.yml runs R8), and builtInKotlin/newDsl require a
-# toolchain/DSL migration of their own.
-android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 agp = "9.3.1"
-kotlin = "2.4.10"
 coreKtx = "1.19.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
@@ -47,7 +46,6 @@ hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testi
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
-jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 hiltAndroid = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 


### PR DESCRIPTION
A `clean build --warning-mode all --no-build-cache` reported seven warnings. Six shared a single root cause, so most of this PR is one migration.

## Root cause

`-Pandroid.debug.obsoleteApi=true` showed the three "obsolete legacy variant API" warnings (`applicationVariants`, `testVariants`, `unitTestVariants`) were emitted by **kotlin-android itself**, not by project code. Migrating to AGP's built-in Kotlin cleared all three, plus the `android.builtInKotlin` / `android.newDsl` opt-out deprecations and the KGP plugin deprecation.

| Warning | Resolution |
|---|---|
| `android.builtInKotlin=false` deprecated | flag removed |
| `android.newDsl=false` deprecated | flag removed |
| `applicationVariants` / `testVariants` / `unitTestVariants` obsolete | cleared by dropping kotlin-android |
| `org.jetbrains.kotlin.android` deprecated | migrated to built-in Kotlin |
| `android.r8.optimizedResourceShrinking=false` deprecated | flag removed |
| `lint { xmlReport / htmlReport }` deprecated | removed; AGP 9 always writes both |

No AGP 9 legacy opt-outs remain in `gradle.properties`.

## Kotlin is now owned by AGP

The `org.jetbrains.kotlin.android` plugin and the catalog's `kotlin` version are both gone, so the Kotlin version follows AGP (2.2.10 for AGP 9.3.1) instead of being pinned independently. `ksp` stays pinned and Dependabot-tracked. CLAUDE.md documents this and warns against re-adding the plugin.

**This is a deliberate trade-off, not an oversight.** It drops the compiler from 2.4.10 to 2.2.10. The alternative — holding the pin via an explicit KGP classpath entry — was considered and rejected in favour of fewer moving parts.

## Deferred follow-ups from #210

Three of the four are closed here:

- **`assembleRelease` now runs in PR CI.** This was #210's stated *precondition* for touching R8, since previously only `release.yml` exercised it. Unsigned, built but never uploaded.
- **Both R8 opt-out flags removed.** `strictFullModeForKeepRules` wasn't warning yet but was the last AGP 9 opt-out.
- **Package-wide ProGuard keep rule removed.** Risk was bounded first: no reflection or dynamic class loading anywhere in app sources, no `android:onClick`, and AGP already generates precise keep rules for the only two XML-referenced classes. Verified via `mapping.txt` that all four name-critical classes keep their fully-qualified names.

  **Release APK: 3,159,819 → 2,710,203 bytes (−449 KB, −14.2%)** — the rule had been exempting the entire app from minification.

The fourth (`r0adkll/upload-google-play` is unmaintained) is a release-pipeline dependency swap, unrelated to warnings.

## Source changes the cache had been hiding

Disabling the build cache surfaced warnings that cached tasks never reprinted:

- Two `@StringRes` annotations now carry explicit use-site targets. `@param:` preserves today's semantics exactly.
- Kotlin 2.2.10 flags four assertions that 2.4.10 did not: `granted is LocationPermissionState` is a compile-time truth for a `val` declared as its concrete singleton type, so those assertions could never fail. The membership claim moved to the declared supertype, where the compiler actually enforces it.

## Lint

Four lint warnings live in the report rather than stdout and were pre-existing:

- **`UseKtx`** — fixed (`canvas.save()`/`restore()` → `Canvas.withSave`).
- **`UnnecessaryRequiredFeature`** — suppressed. GPS `required="true"` is load-bearing Play Store device filtering, already documented as intentional.
- **`PluralsCandidate`** — suppressed. `"Satellites: %1$d used / %2$d visible"` has two independent counts; a `<plurals>` resource selects on one, so it is structurally unfixable.

Both suppressions carry their rationale at the decision site.

**`OldTargetApi` is left open deliberately** — `targetSdk = 36` against `compileSdk = 37`. Bumping it opts the app into new platform behavior at runtime and needs device testing, particularly around the location and sensor duty-cycling. That belongs in its own PR.

## Verification

`clean build --warning-mode all --no-build-cache`: exit 0, **69/69 unit tests pass**, zero compile or configuration warnings. `androidTest` sources compiled separately via `assembleDebugAndroidTest` (`build` never touches them) — also clean.

**One gap worth naming:** instrumented tests run `connectedDebugAndroidTest`, and debug is unminified, so nothing runtime-tests the narrowed ProGuard rules. Verification here is static. Given zero reflection the risk is low, but a missed reflective path would surface as a crash on the internal track rather than in CI. Closing that properly means a minified, debug-signed build type for instrumented tests — a design change, so it is not folded in here.
