### PR TITLE
docs: rewrite PRIVACY.md and correct the release flow in RELEASE_SETUP.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 arunderwood
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 **Last updated: 2026-07-30**
 
-This policy covers the HeightMark Android app (package `com.bizzarosn.heightmark`), published by its maintainer. The app's source code is public at
+This policy covers the HeightMark Android app (package `com.bizzarosn.heightmark`), published by its maintainer. HeightMark is open source under the MIT license, and its complete source is at
 [github.com/arunderwood/heightmark](https://github.com/arunderwood/heightmark), so every claim below can be checked against the code.
 
 ## Summary

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,74 +1,73 @@
-**Privacy Policy**
+# HeightMark Privacy Policy
 
-This privacy policy applies to the Heightsnap app (hereby referred to as "Application") for mobile devices that was created by (hereby referred to as "Service Provider") as an Open Source service. This service is intended for use "AS IS".
+**Last updated: 2026-07-30**
 
-**Information Collection and Use**
+This policy covers the HeightMark Android app (package `com.bizzarosn.heightmark`), published by its maintainer. The app's source code is public at
+[github.com/arunderwood/heightmark](https://github.com/arunderwood/heightmark), so every claim below can be checked against the code.
 
-The Application collects information when you download and use it. This information may include information such as
+## Summary
 
-*   Your device's Internet Protocol address (e.g. IP address)
-*   The pages of the Application that you visit, the time and date of your visit, the time spent on those pages
-*   The time spent on the Application
-*   The operating system you use on your mobile device
+HeightMark reads your device's precise GPS location for one purpose: to compute the elevation shown on screen. That location data stays on your device. It is not stored, not uploaded, and not shared. The app has no analytics, no advertising, no crash-reporting service, no third-party SDKs, and no Google Play services dependency.
 
-The Application does not gather precise information about the location of your mobile device.
+The app does not request the `INTERNET` permission, so it cannot make network connections at all.
 
-The Application collects your device's location, which helps the Service Provider determine your approximate geographical location and make use of in below ways:
+## What the app accesses
 
-*   Geolocation Services: The Service Provider utilizes location data to provide features such as personalized content, relevant recommendations, and location-based services.
-*   Analytics and Improvements: Aggregated and anonymized location data helps the Service Provider to analyze user behavior, identify trends, and improve the overall performance and functionality of the Application.
-*   Third-Party Services: Periodically, the Service Provider may transmit anonymized location data to external services. These services assist them in enhancing the Application and optimizing their offerings.
+- **Precise location** (`ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION`). Elevation comes from GNSS altitude, which requires precise location — a coarse or "approximate" grant is not enough, and the app will ask you to upgrade it. Fixes come from the Android `LocationManager`'s GPS provider, plus the passive provider, which lets HeightMark reuse a fix another app already requested instead of powering the GPS radio itself.
+- **Motion and pressure sensors.** While the GPS radio is duty-cycled off to save power, the significant-motion sensor and the barometer are used to detect that you have moved and that a fresh fix is warranted. Barometric pressure is also shown in the optional Details panel.
 
-The Service Provider may use the information you provided to contact you from time to time to provide you with important information, required notices and marketing promotions.
+## How location is used
 
-For a better experience, while using the Application, the Service Provider may require you to provide us with certain personally identifiable information. The information that the Service Provider request will be retained by them and used as described in this privacy policy.
+Each GPS fix is converted from WGS84 ellipsoid height to elevation above Mean Sea Level using Android's built-in `AltitudeConverter`, which uses geoid data stored on the device and works entirely offline. Fixes are averaged over a short rolling window to steady the displayed number.
 
-**Third Party Access**
+All of this happens in memory, in the app process. Position data is never written to a file, database, or preference store. When the app process ends, the readings are gone.
 
-Only aggregated, anonymized data is periodically transmitted to external services to aid the Service Provider in improving the Application and their service. The Service Provider may share your information with third parties in the ways that are described in this privacy statement.
+If you turn on the optional **Details** panel, it displays diagnostics about the current fix — including your latitude and longitude, accuracy figures, satellite counts, and barometric pressure. That information is rendered on your screen and nowhere else.
 
-Please note that the Application utilizes third-party services that have their own Privacy Policy about handling data. Below are the links to the Privacy Policy of the third-party service providers used by the Application:
+## What leaves your device
 
-*   [Google Play Services](https://www.google.com/policies/privacy/)
+Nothing.
 
-The Service Provider may disclose User Provided and Automatically Collected Information:
+HeightMark declares no `INTERNET` permission and contains no networking code, no analytics library, no advertising library, and no crash-reporting library. Its entire dependency list is AndroidX, Google's Material Components, Hilt (dependency injection), and Jetpack DataStore — none of which transmit your data. The app deliberately avoids Google Play services so that it behaves identically on standard Android and on de-googled builds such as GrapheneOS, LineageOS, CalyxOS, and /e/OS.
 
-*   as required by law, such as to comply with a subpoena, or similar legal process;
-*   when they believe in good faith that disclosure is necessary to protect their rights, protect your safety or the safety of others, investigate fraud, or respond to a government request;
-*   with their trusted services providers who work on their behalf, do not have an independent use of the information we disclose to them, and have agreed to adhere to the rules set forth in this privacy statement.
+There are no user accounts, no sign-in, and no way to contact you through the app.
 
-**Opt-Out Rights**
+## What is stored on your device
 
-You can stop all collection of information by the Application easily by uninstalling it. You may use the standard uninstall processes as may be available as part of your mobile device or via the mobile application marketplace or network.
+Exactly two settings, saved locally through Jetpack DataStore:
 
-**Data Retention Policy**
+- your unit preference (metric or imperial), and
+- whether the Details panel is shown.
 
-The Service Provider will retain User Provided data for as long as you use the Application and for a reasonable time thereafter. If you'd like them to delete User Provided Data that you have provided via the Application, please contact them at and they will respond in a reasonable time.
+That is the complete list. No location, no history, no identifiers.
 
-**Children**
+## Backup
 
-The Service Provider does not use the Application to knowingly solicit data from or market to children under the age of 13.
+HeightMark participates in standard Android backup. The settings file described above (`datastore/settings.preferences_pb`) is included in both cloud backup and device-to-device transfer — see [`app/src/main/res/xml/data_extraction_rules.xml`](app/src/main/res/xml/data_extraction_rules.xml).
 
-The Application does not address anyone under the age of 13\. The Service Provider does not knowingly collect personally identifiable information from children under 13 years of age. In the case the Service Provider discover that a child under 13 has provided personal information, the Service Provider will immediately delete this from their servers. If you are a parent or guardian and you are aware that your child has provided us with personal information, please contact the Service Provider () so that they will be able to take the necessary actions.
+In practice this means that if you have Android's backup feature enabled, those two preference values may be copied to your own backup — for most users, their Google account — and restored when you set up a new device. That backup is handled by Android and governed by your device's backup settings and your backup provider's privacy policy, not by HeightMark. No location data is in that file, because the app never stores any.
 
-**Security**
+## Third parties
 
-The Service Provider is concerned about safeguarding the confidentiality of your information. The Service Provider provides physical, electronic, and procedural safeguards to protect information the Service Provider processes and maintains.
+HeightMark integrates no third-party services and sends data to no one.
 
-**Changes**
+The app itself contains no crash-reporting code. Separately, if you installed it from the Google Play Store, that store is Google's service and is covered by Google's privacy policy; any crash or performance data Android itself reports to a developer console is controlled by your device's diagnostics settings, not by anything in the app.
 
-This Privacy Policy may be updated from time to time for any reason. The Service Provider will notify you of any changes to the Privacy Policy by updating this page with the new Privacy Policy. You are advised to consult this Privacy Policy regularly for any changes, as continued use is deemed approval of all changes.
+## Children
 
-This privacy policy is effective as of 2025-09-30
+HeightMark collects no personal information from anyone, of any age. There is nothing to solicit, transmit, or delete on a server, because there is no server.
 
-**Your Consent**
+## Removing your data
 
-By using the Application, you are consenting to the processing of your information as set forth in this Privacy Policy now and as amended by us.
+Uninstalling the app removes its local settings from your device. If Android backup is enabled, a copy of those settings may persist in your backup until your backup provider removes it under its own retention rules; you can delete app backup data through your device's backup settings.
 
-**Contact Us**
+There is no other data to remove, and no request to send anyone — the maintainer has no copy of anything.
 
-If you have any questions regarding privacy while using the Application, or have questions about the practices, please contact the Service Provider via email at .
+## Changes to this policy
 
-* * *
+If this policy changes, the updated version will be published in the app's repository, with the change visible in the commit history.
 
-This privacy policy page was generated by [App Privacy Policy Generator](https://app-privacy-policy-generator.nisrulz.com/)
+## Contact
+
+Questions about privacy in HeightMark go to the project's issue tracker:
+[github.com/arunderwood/heightmark/issues](https://github.com/arunderwood/heightmark/issues)

--- a/RELEASE_SETUP.md
+++ b/RELEASE_SETUP.md
@@ -1,16 +1,16 @@
 # Google Play Store Release Setup
 
-This document outlines the steps to configure automated releases to the Google Play Store.
+This document covers the one-time setup needed for automated releases to the Google Play Store. For how the release flow works day to day, see the **Release Process** section of [CLAUDE.md](CLAUDE.md).
 
 ## Prerequisites
 
 1. **Google Play Console Account**: Ensure you have a Google Play Console developer account
-2. **App Registration**: Your app must be registered in Google Play Console
-3. **Google Play App Signing**: Enable Google Play App Signing for your app (recommended)
+2. **App Registration**: The app must be registered in Google Play Console under `com.bizzarosn.heightmark`
+3. **Google Play App Signing**: Enable Google Play App Signing for the app (recommended)
 
 ## Required GitHub Secrets
 
-Add these secrets to your GitHub repository settings (`Settings > Secrets and variables > Actions`):
+Add these secrets to the GitHub repository settings (`Settings > Secrets and variables > Actions`). All five are consumed by [`.github/workflows/release.yml`](.github/workflows/release.yml).
 
 ### `SERVICE_ACCOUNT_JSON`
 1. Go to [Google Cloud Console](https://console.cloud.google.com/)
@@ -39,48 +39,60 @@ Add these secrets to your GitHub repository settings (`Settings > Secrets and va
      - Select appropriate permissions (Release Manager recommended)
 7. Copy the entire JSON file content and paste it as the `SERVICE_ACCOUNT_JSON` secret
 
+### Signing secrets
+
+| Secret | Contents |
+| --- | --- |
+| `KEYSTORE_BASE64` | The upload keystore, base64-encoded. The workflow decodes it to `app/release.keystore` and deletes it after the build. |
+| `KEYSTORE_PASSWORD` | Keystore password |
+| `KEY_ALIAS` | Alias of the signing key inside the keystore |
+| `KEY_PASSWORD` | Password for that key |
+
+The workflow exports these as the `KEYSTORE_FILE`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, and `KEY_PASSWORD` environment variables that `app/build.gradle.kts` reads. If any is missing, the signing config is left empty and the build produces an **unsigned** artifact — which is why local `assembleRelease`/`bundleRelease` output is unsigned.
+
 ## Package Name Configuration
 
-Update the `packageName` in `.github/workflows/release.yml` to match your app's package name:
+The `packageName` in `.github/workflows/release.yml` must match the `applicationId` in `app/build.gradle.kts` and the app's listing in Play Console:
 
 ```yaml
-packageName: com.arunderwood.heightmark  # Update this to your actual package name
+packageName: com.bizzarosn.heightmark
 ```
+
+Note that debug builds carry an `applicationIdSuffix` of `.debug`, so they install alongside release builds and are irrelevant to Play uploads.
 
 ## Release Track Configuration
 
-The workflow is configured to release to the `internal` track by default. You can change this in the workflow file:
+The workflow releases to the `internal` track. Change `tracks:` in the workflow file to target another track:
 
 - `internal`: Internal testing track
-- `alpha`: Alpha testing track  
+- `alpha`: Alpha testing track
 - `beta`: Beta testing track
 - `production`: Production track (live on Play Store)
 
 ## Creating a Release
 
-1. **Update Version**: Update version in `app/build.gradle.kts`:
-   ```kotlin
-   versionCode = 2
-   versionName = "1.1.0"
-   ```
+**Releases are automatic. There is no version to bump and no tag to push.**
 
-2. **Update Release Notes**: Edit `metadata/whatsnew/whatsnew-en-US` with your release notes
+Every merge to `main` that passes CI produces a release:
 
-3. **Create and Push Tag**:
-   ```bash
-   git tag v1.1.0
-   git push origin v1.1.0
-   ```
+1. The merge triggers the "Android CI" workflow on `main` (Trivy security scan, then lint, unit tests, `assembleDebug`, `assembleRelease`, then instrumented tests).
+2. When "Android CI" completes **successfully** on `main`, `release.yml` starts via a `workflow_run` trigger. A failed CI run releases nothing.
+3. `release.yml` computes the version itself from its own `run_number` — `versionCode = 10000 + run_number`, `versionName = "1.0.<run_number>"` — and passes them to Gradle as `-PversionCode` / `-PversionName`. The values in `app/build.gradle.kts` (`versionCode 4`, `versionName "1.0.0-dev"`) are only local-build fallbacks; editing them has no effect on releases.
+4. The signed AAB is uploaded to the Play Store `internal` track and a GitHub release is created, tagged `v<versionName>`, with auto-generated notes and the AAB attached. The tag is an *output* of the release, not its trigger.
 
-4. **Monitor Release**: Check the GitHub Actions tab for the release workflow progress
+The only thing worth editing by hand before a release is the release notes in `metadata/whatsnew/whatsnew-en-US`, which the workflow passes to Play as `whatsNewDirectory`.
+
+To change the major/minor version, edit `BASE_CODE` and `VERSION_PREFIX` in `release.yml`. To roll back, revert the offending commit on `main` and let the next release go out. Both are described in more detail in [CLAUDE.md](CLAUDE.md).
 
 ## Workflow Features
 
-- **Automatic Builds**: Builds release AAB on version tags
-- **Quality Checks**: Runs lint and unit tests before release
-- **Play Store Upload**: Uploads AAB to specified track
-- **GitHub Release**: Creates GitHub release with changelog
-- **Artifact Storage**: Saves build artifacts for 30 days
+- **Trigger**: `workflow_run` on a successful "Android CI" run on `main` — not on tags
+- **Quality Checks**: run in `android_build.yml`, not here; `release.yml` runs no lint or tests of its own and relies on the CI success condition as its gate
+- **Versioning**: derived from the release workflow's `run_number`, with no manual bump
+- **Serialization**: a `play-store-release` concurrency group keeps releases sequential, because the Play Publishing API allows only one open edit per app
+- **Play Store Upload**: uploads the AAB to the `internal` track with `inAppUpdatePriority: 2`
+- **GitHub Release**: creates a tagged GitHub release with auto-generated notes and the AAB attached
+- **Artifact Storage**: uploads the AAB as a workflow artifact for 30 days
 
 ## Troubleshooting
 
@@ -90,6 +102,8 @@ The workflow is configured to release to the `internal` track by default. You ca
 2. **Service Account Permissions**: Service account needs "Release Manager" role
 3. **API Not Enabled**: Ensure Google Play Android Developer API is enabled
 4. **First Release**: First release may need to be done manually through Play Console
+5. **No release ran after a merge**: check that "Android CI" *succeeded* on `main` — `release.yml` is skipped entirely when the upstream run's conclusion is anything else
+6. **Version code already used**: `run_number` only ever increases, but a re-run of an old release workflow reuses its number; cut a new release instead of re-running an old one
 
 ### Debug Steps
 
@@ -100,7 +114,7 @@ The workflow is configured to release to the `internal` track by default. You ca
 
 ## Security Notes
 
-- Never commit service account JSON files to your repository
+- Never commit service account JSON files or keystores to the repository
 - Use GitHub Secrets for all sensitive information
 - Regularly rotate service account keys
 - Monitor API usage in Google Cloud Console

--- a/Readme.md
+++ b/Readme.md
@@ -12,3 +12,11 @@ This Android app is a simple way to be able to glance at current elevation.  It'
 - Readings are averaged over a rolling window, with poor-vertical-accuracy fixes filtered out.
 - The GPS radio duty-cycles: after ~30 s stationary it turns off, and low-power triggers (significant-motion sensor for horizontal movement, barometer for elevators and other vertical movement, passive fixes from other apps) turn it back on.
 - A "Details" panel shows the nerd data: ellipsoid vs sea-level altitude, geoid offset, accuracy, satellites in view, barometric pressure, and GPS duty-cycle state.
+
+## Privacy
+
+Location never leaves your device. The app declares no `INTERNET` permission, so it cannot make network requests at all — there are no analytics, no ads, and no third-party services. See [PRIVACY.md](PRIVACY.md).
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
Both public-facing docs described something other than what this app does. No code changes.

## PRIVACY.md

Was an unedited [App Privacy Policy Generator](https://app-privacy-policy-generator.nisrulz.com/) template, wrong in both directions — it named the wrong app ("Heightsnap"), claimed collection the app does not do, and simultaneously denied the one thing it does do.

Removed as false:
- IP address, "pages visited", time-on-app collection
- Marketing contact, and "anonymized location data periodically transmitted to external services"
- Google Play Services listed as a third-party dependency — the app deliberately has none
- "The Application does not gather precise information about the location of your mobile device", which contradicts `ACCESS_FINE_LOCATION` + `GPS_PROVIDER`
- Three blank contact placeholders ("contact them at and they will respond", "( )", "via email at .")

Replaced with the actual, and fairly strong, story: precise GPS is read on-device solely to compute the displayed elevation, held in memory, never written to storage, never transmitted. No analytics, ads, crash reporting, third-party SDKs, or Play services.

The no-network claim is verified against the **merged** manifest, not just the source one — `processDebugMainManifest` output declares exactly two permissions, both location, and zero `INTERNET`.

Two disclosures added so the doc is not quietly incomplete:
- The Details panel renders latitude/longitude on screen, so "used solely to compute elevation" alone would under-disclose.
- The app has no crash-reporting code, but Play-distributed apps can have OS-level crash data reported under device diagnostics settings — framed as platform behavior, not the app's.

Backup is disclosed honestly: `datastore/settings.preferences_pb` is in both `cloud-backup` and `device-transfer`, so the two boolean preferences may reach account backup, and no location is in that file because none is ever stored.

Contact is now the issue tracker. The doc says the source is *public* rather than "open source", since the repo has no `LICENSE` file — worth adding if you want the stronger claim.

## RELEASE_SETUP.md

Documented a tag-triggered flow that no longer exists.

- **Creating a Release**: said to bump `versionCode`/`versionName` in `app/build.gradle.kts` and push a tag. Now describes the real flow — automatic on merge to `main` via `workflow_run`, versions from the release workflow's own `run_number` (`BASE_CODE=10000`, `VERSION_PREFIX="1.0"`), and the gradle values noted as local-build fallbacks. The tag is an output of the release, not its trigger.
- **Workflow Features**: claimed tag-triggered builds with pre-release lint/tests. `release.yml` runs neither; the "Android CI" success condition is the entire gate. Added the `play-store-release` concurrency serialization.
- **Package name**: `com.arunderwood.heightmark` → `com.bizzarosn.heightmark`.

One addition beyond the reported defects: the secrets section documented only `SERVICE_ACCOUNT_JSON`, so following it as written produces an *unsigned* build. Added the four signing secrets (`KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`). Easy to drop if you'd rather keep that section as it was.