### PR TITLE
fix: recover from a corrupted preferences DataStore instead of crash-looping

### DIFF
--- a/app/src/main/java/com/bizzarosn/heightmark/PreferencesRepository.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/PreferencesRepository.kt
@@ -2,17 +2,24 @@ package com.bizzarosn.heightmark
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "settings",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() }
+)
 
 private object PreferencesKeys {
     val USE_METRIC_UNIT = booleanPreferencesKey("use_metric_unit")
@@ -38,7 +45,11 @@ class PreferencesRepository @Inject constructor(@ApplicationContext context: Con
     }
 
     private fun booleanFlow(key: Preferences.Key<Boolean>, default: Boolean): Flow<Boolean> =
-        dataStore.data.map { preferences -> preferences[key] ?: default }
+        dataStore.data
+            .catch { exception ->
+                if (exception is IOException) emit(emptyPreferences()) else throw exception
+            }
+            .map { preferences -> preferences[key] ?: default }
 
     private suspend fun setBoolean(key: Preferences.Key<Boolean>, value: Boolean) {
         dataStore.edit { preferences -> preferences[key] = value }


### PR DESCRIPTION
## Summary
- Register a `ReplaceFileCorruptionHandler` on the `settings` DataStore delegate so a corrupted `settings.preferences_pb` gets replaced with an empty store instead of rethrowing `CorruptionException` on every read.
- Add a `.catch` for `IOException` before the `map` in `booleanFlow`, so any other read-time I/O failure falls back to defaults rather than propagating into `ElevationFragment`'s uncaught `lifecycleScope.launch` blocks.

## Why
The default `NoOpCorruptionHandler` never replaces the corrupted file, so once the preferences file is corrupted (a truncated `settings.preferences_pb` from a bad backup/restore is the realistic trigger, since `data_extraction_rules.xml` backs this file up under both cloud backup and device transfer, and `allowBackup=true`), the app crashes on *every* subsequent launch — a persistent crash loop rather than a one-off failure.

## Scope decision
Left the two fragment write sites (`setUseMetricUnit` / `setShowDetails`) unguarded. `dataStore.edit` does an internal read-modify-write, and the corruption handler is registered on the `DataStore` itself, so it already covers the read half of that write — the reported crash-loop shape (persistent corrupt file → crash every launch) is closed off. A residual `IOException` during the write itself (disk full, permissions) is transient rather than persistent, so it doesn't reproduce the crash-loop and isn't worth silently swallowing.

## Test plan
- [x] `./gradlew build` (lint, unit tests, debug + release assemble) passes
- [ ] No new unit test added: `PreferencesRepository` requires a real/faked Android `Context` to build its DataStore, and the project has no Robolectric dependency to provide one on the JVM. Exercising the corruption path would need Robolectric or an instrumented test — flagging as a known coverage gap rather than adding a new test dependency for this one fix.