### PR TITLE
fix: weight elevation average by fix accuracy and grow the settle window

### DIFF
--- a/app/src/main/java/com/bizzarosn/heightmark/DetailsPanelPresenter.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/DetailsPanelPresenter.kt
@@ -63,7 +63,12 @@ object DetailsPanelPresenter {
             rows += Row(
                 R.string.detail_accuracy,
                 listOf(
-                    input.lengthOrUnknown(location.verticalAccuracyOrNull()),
+                    // MSL accuracy bounds the number actually on screen (geoid
+                    // model error included); the raw ellipsoidal figure is a
+                    // fallback for when the platform or a fix doesn't have it.
+                    input.lengthOrUnknown(
+                        location.mslAltitudeAccuracyOrNull() ?: location.verticalAccuracyOrNull()
+                    ),
                     input.lengthOrUnknown(location.horizontalAccuracyOrNull())
                 )
             )

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationService.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationService.kt
@@ -107,16 +107,35 @@ class ElevationService(private val readingsCount: Int) {
         return sqrt(variance)
     }
 
+    // Inverse-variance weighted: a precise fix pulls the average toward itself
+    // much harder than a marginal one, instead of moving it exactly as far as
+    // any other reading admitted into the window.
     private fun getAverageElevation(): Double {
-        return window.map { it.elevationMeters }.average()
+        var weightedSum = 0.0
+        var totalWeight = 0.0
+        window.forEach { reading ->
+            val accuracy = max(reading.accuracyMeters.toDouble(), WEIGHT_ACCURACY_FLOOR_M)
+            val weight = 1.0 / (accuracy * accuracy)
+            weightedSum += reading.elevationMeters * weight
+            totalWeight += weight
+        }
+        return weightedSum / totalWeight
     }
 
     companion object {
-        const val DEFAULT_WINDOW_SIZE = 10
+        // ~30 readings at the tracker's 1 Hz update interval, spanning the
+        // stationary period before the duty cycle turns the GPS radio off
+        // (StillnessDetector's default window), rather than judging "settled"
+        // over a few seconds of nearly fully correlated GNSS vertical error.
+        const val DEFAULT_WINDOW_SIZE = 30
         const val DEFAULT_VERTICAL_ACCURACY_M = 10f
         const val JUMP_CONFIRM_COUNT = 3
         const val JUMP_THRESHOLD_FLOOR_M = 8.0
         const val SETTLE_STDDEV_FLOOR_M = 4.0
         const val SETTLE_ACCURACY_FACTOR = 0.75
+        // A reading claiming sub-meter accuracy should not dominate the
+        // average by a huge margin over one claiming 1 m; this bounds the
+        // weight ratio between the best and worst admitted fixes.
+        const val WEIGHT_ACCURACY_FLOOR_M = 1.0
     }
 }

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationSession.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationSession.kt
@@ -77,11 +77,21 @@ class ElevationSession @Inject constructor(
      * Adds a converted fix to the average, unless its window was flushed while
      * it was converting. Returns true when the reading was applied and the
      * screen needs a repaint.
+     *
+     * [accuracyMeters] weighs the reading in the average and feeds the settle
+     * threshold; it defaults to the fix's pre-conversion vertical accuracy but
+     * callers that resolved a tighter bound afterward — the MSL altitude
+     * accuracy the geoid conversion can populate — should pass that instead,
+     * since it is what actually bounds [elevationMeters].
      */
-    fun commit(pending: PendingFix, elevationMeters: Double): Boolean {
+    fun commit(
+        pending: PendingFix,
+        elevationMeters: Double,
+        accuracyMeters: Float? = pending.verticalAccuracyMeters
+    ): Boolean {
         if (pending.epoch != epoch) return false
         displayedElevationMeters = elevationService
-            .addElevationReading(elevationMeters, pending.verticalAccuracyMeters)
+            .addElevationReading(elevationMeters, accuracyMeters)
             .averageMeters
         hasFix = true
         awaitingFreshFix = false

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationTracker.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationTracker.kt
@@ -215,8 +215,12 @@ class ElevationTracker @Inject constructor(
             val elevation = withContext(Dispatchers.IO) {
                 altitudeResolver.mslAltitudeMeters(location)
             }
+            // The conversion may have populated a tighter, post-conversion
+            // accuracy bound on the same Location; prefer it over the
+            // pre-conversion figure session.offer() captured
+            val accuracy = location.mslAltitudeAccuracyOrNull() ?: pending.verticalAccuracyMeters
             // The window was flushed while this fix was converting: drop it
-            if (!session.commit(pending, elevation)) return@launch
+            if (!session.commit(pending, elevation, accuracy)) return@launch
             lastLocation = location
             publish()
         }

--- a/app/src/main/java/com/bizzarosn/heightmark/LocationAccuracy.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/LocationAccuracy.kt
@@ -16,3 +16,13 @@ fun Location.verticalAccuracyOrNull(): Float? =
 /** Horizontal accuracy in meters, or null when the fix does not report one. */
 fun Location.horizontalAccuracyOrNull(): Float? =
     if (hasAccuracy()) accuracy else null
+
+/**
+ * MSL altitude accuracy in meters (API 34), or null when unavailable — either
+ * the platform is older, or [android.location.altitude.AltitudeConverter]
+ * never populated it (no geoid data, ellipsoid fallback). Unlike
+ * [verticalAccuracyOrNull], this bounds the error of the converted,
+ * sea-level number actually shown on screen, geoid model error included.
+ */
+fun Location.mslAltitudeAccuracyOrNull(): Float? =
+    if (hasMslAltitudeAccuracy()) mslAltitudeAccuracyMeters else null

--- a/app/src/main/java/com/bizzarosn/heightmark/ReadingState.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ReadingState.kt
@@ -1,5 +1,7 @@
 package com.bizzarosn.heightmark
 
+import kotlin.math.sqrt
+
 /**
  * What the current elevation reading is worth, derived from [ElevationSession]'s
  * tracking flags and the averaging window. Reaches the screen through
@@ -10,7 +12,17 @@ sealed interface ReadingState {
     data object Acquiring : ReadingState
 
     /** Averaging toward a settled value; [progress] is the window fill (0..1). */
-    data class Converging(val progress: Float) : ReadingState
+    data class Converging(val progress: Float) : ReadingState {
+        /**
+         * What [progress] should look like on screen. A window sized for
+         * minutes-scale GNSS bias decorrelation takes tens of seconds to
+         * fill, but visual confidence should build faster than that: a
+         * square-root curve front-loads the ramp so early readings already
+         * read as trustworthy, while the literal fill fraction still governs
+         * the settle latch.
+         */
+        val visualProgress: Float get() = sqrt(progress.coerceIn(0f, 1f))
+    }
 
     /** Window full and tight: the displayed value can be trusted. */
     data object Stable : ReadingState
@@ -40,7 +52,7 @@ sealed interface ReadingState {
          */
         fun heroAlpha(state: ReadingState): Float = when (state) {
             Dormant -> DIMMED_TEXT_ALPHA
-            is Converging -> DIMMED_TEXT_ALPHA + (1f - DIMMED_TEXT_ALPHA) * state.progress
+            is Converging -> DIMMED_TEXT_ALPHA + (1f - DIMMED_TEXT_ALPHA) * state.visualProgress
             Acquiring, Stable -> 1f
         }
 

--- a/app/src/main/java/com/bizzarosn/heightmark/StabilityLineView.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/StabilityLineView.kt
@@ -113,7 +113,7 @@ class StabilityLineView @JvmOverloads constructor(
             spokenRes = R.string.stability_acquiring
         )
         is ReadingState.Converging -> {
-            val p = state.progress.coerceIn(0f, 1f)
+            val p = state.visualProgress
             StatePresentation(
                 amplitude = 1f - p, core = p, dormantMix = 0f,
                 spokenRes = R.string.stability_converging

--- a/app/src/test/java/com/bizzarosn/heightmark/DetailsPanelPresenterTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/DetailsPanelPresenterTest.kt
@@ -136,6 +136,26 @@ class DetailsPanelPresenterTest {
     }
 
     @Test
+    fun `the accuracy row prefers MSL altitude accuracy over ellipsoidal vertical accuracy`() {
+        val location = TestLocations.detailsFix(verticalAccuracy = 8f, mslAltitudeAccuracy = 2.5f)
+
+        val accuracy = DetailsPanelPresenter.rows(input(location = location))
+            .first { it.templateRes == R.string.detail_accuracy }
+
+        assertEquals(listOf(meters("2.5"), UNKNOWN_VALUE), accuracy.args)
+    }
+
+    @Test
+    fun `the accuracy row falls back to vertical accuracy without an MSL figure`() {
+        val location = TestLocations.detailsFix(verticalAccuracy = 8f, mslAltitudeAccuracy = null)
+
+        val accuracy = DetailsPanelPresenter.rows(input(location = location))
+            .first { it.templateRes == R.string.detail_accuracy }
+
+        assertEquals(listOf(meters("8.0"), UNKNOWN_VALUE), accuracy.args)
+    }
+
+    @Test
     fun `the pressure row is omitted on a barometer-less device`() {
         val rows = DetailsPanelPresenter.rows(input(pressureHpa = null))
 

--- a/app/src/test/java/com/bizzarosn/heightmark/ElevationServiceTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/ElevationServiceTest.kt
@@ -77,6 +77,27 @@ class ElevationServiceTest {
         assertEquals(100.5, result.averageMeters, 0.001)
     }
 
+    // --- Inverse-variance weighting ---
+
+    @Test
+    fun `weighted average favors the more accurate reading`() {
+        elevationService.addElevationReading(100.0, verticalAccuracyMeters = 10f)
+        val result = elevationService.addElevationReading(104.0, verticalAccuracyMeters = 1f)
+
+        // weight(10 m) = 1 / 10^2 = 0.01, weight(1 m) = 1 / 1^2 = 1
+        // (100 x 0.01 + 104 x 1) / 1.01
+        assertEquals(103.960, result.averageMeters, 0.001)
+    }
+
+    @Test
+    fun `weight accuracy floor treats sub-meter accuracy as one meter`() {
+        elevationService.addElevationReading(100.0, verticalAccuracyMeters = 0.1f)
+        val result = elevationService.addElevationReading(102.0, verticalAccuracyMeters = 0.5f)
+
+        // Both accuracies are floored to 1 m before weighting, so they weigh equally
+        assertEquals(101.0, result.averageMeters, 0.001)
+    }
+
     // --- Jump detection ---
 
     @Test

--- a/app/src/test/java/com/bizzarosn/heightmark/ElevationSessionTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/ElevationSessionTest.kt
@@ -69,6 +69,31 @@ class ElevationSessionTest {
     }
 
     @Test
+    fun `commit's accuracy override supersedes the pre-conversion accuracy for weighting`() {
+        val first = session.offer(TestLocations.fixForAdmission(verticalAccuracy = 10f))!!
+        session.commit(first, 100.0, accuracyMeters = 10f)
+
+        val second = session.offer(TestLocations.fixForAdmission(verticalAccuracy = 10f))!!
+        // A resolved accuracy far tighter than what admission captured (e.g. a
+        // post-conversion MSL figure) should dominate the weighted average
+        session.commit(second, 106.0, accuracyMeters = 1f)
+
+        // weight(10 m) = 0.01, weight(1 m) = 1: (100 x 0.01 + 106 x 1) / 1.01
+        assertEquals(105.941, session.displayedElevationMeters!!, 0.001)
+    }
+
+    @Test
+    fun `commit without an override weighs by the fix's pre-conversion accuracy`() {
+        val loose = session.offer(TestLocations.fixForAdmission(verticalAccuracy = 10f))!!
+        session.commit(loose, 100.0)
+
+        val tight = session.offer(TestLocations.fixForAdmission(verticalAccuracy = 1f))!!
+        session.commit(tight, 106.0)
+
+        assertEquals(105.941, session.displayedElevationMeters!!, 0.001)
+    }
+
+    @Test
     fun `a fix converted across a wake is dropped`() {
         addReading(100.0)
         val pending = session.offer(TestLocations.fixForAdmission())!!

--- a/app/src/test/java/com/bizzarosn/heightmark/LocationAccuracyTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/LocationAccuracyTest.kt
@@ -40,4 +40,18 @@ class LocationAccuracyTest {
 
         assertEquals(0f, reported.verticalAccuracyOrNull()!!, 0.001f)
     }
+
+    @Test
+    fun `MSL altitude accuracy is null when the fix does not report one`() {
+        val location = TestLocations.detailsFix(mslAltitudeAccuracy = null)
+
+        assertNull(location.mslAltitudeAccuracyOrNull())
+    }
+
+    @Test
+    fun `MSL altitude accuracy is returned when the fix reports one`() {
+        val location = TestLocations.detailsFix(mslAltitudeAccuracy = 2.5f)
+
+        assertEquals(2.5f, location.mslAltitudeAccuracyOrNull()!!, 0.001f)
+    }
 }

--- a/app/src/test/java/com/bizzarosn/heightmark/ReadingStateTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/ReadingStateTest.kt
@@ -2,6 +2,7 @@ package com.bizzarosn.heightmark
 
 import org.junit.Assert.*
 import org.junit.Test
+import kotlin.math.sqrt
 
 class ReadingStateTest {
 
@@ -82,12 +83,20 @@ class ReadingStateTest {
     fun `converging ramps the hero from dimmed to full as the window fills`() {
         val dimmed = ReadingState.DIMMED_TEXT_ALPHA
         assertEquals(dimmed, ReadingState.heroAlpha(ReadingState.Converging(0f)), 1e-6f)
+        // The ramp follows visualProgress (sqrt of fill), not fill linearly
         assertEquals(
-            dimmed + (1f - dimmed) / 2f,
+            dimmed + (1f - dimmed) * sqrt(0.5f),
             ReadingState.heroAlpha(ReadingState.Converging(0.5f)),
             1e-6f
         )
         assertEquals(1f, ReadingState.heroAlpha(ReadingState.Converging(1f)), 1e-6f)
+    }
+
+    @Test
+    fun `visualProgress front-loads the ramp ahead of the literal window fill`() {
+        val state = ReadingState.Converging(0.25f)
+        assertEquals(0.25f, state.progress, 1e-6f)
+        assertEquals(0.5f, state.visualProgress, 1e-6f)
     }
 
     @Test

--- a/app/src/test/java/com/bizzarosn/heightmark/TestLocations.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/TestLocations.kt
@@ -25,6 +25,7 @@ object TestLocations {
         msl: Double? = null,
         verticalAccuracy: Float? = null,
         horizontalAccuracy: Float? = null,
+        mslAltitudeAccuracy: Float? = null,
         latitude: Double = 0.0,
         longitude: Double = 0.0,
         atNanos: Long = 0L
@@ -34,6 +35,8 @@ object TestLocations {
         verticalAccuracy?.let { every { location.verticalAccuracyMeters } returns it }
         every { location.hasAccuracy() } returns (horizontalAccuracy != null)
         horizontalAccuracy?.let { every { location.accuracy } returns it }
+        every { location.hasMslAltitudeAccuracy() } returns (mslAltitudeAccuracy != null)
+        mslAltitudeAccuracy?.let { every { location.mslAltitudeAccuracyMeters } returns it }
         every { location.latitude } returns latitude
         every { location.longitude } returns longitude
         every { location.elapsedRealtimeNanos } returns atNanos


### PR DESCRIPTION
## Summary
- Weight `ElevationService`'s rolling average by inverse variance (`1/max(accuracy, 1)^2`) instead of averaging elevations unweighted, so a precise fix pulls the displayed value harder than a marginal one. The hard admission gate (50 m) stays as-is.
- Grow `DEFAULT_WINDOW_SIZE` 10 → 30 (~30 s at 1 Hz) so "settled" spans the stationary period before the duty cycle idles the GPS radio, rather than a few seconds of nearly fully correlated GNSS vertical error. Added `ReadingState.Converging.visualProgress` (a sqrt curve) so the hero-alpha ramp and settling line still feel responsive over the longer fill; the settle-latch math itself is untouched.
- Prefer the post-conversion MSL altitude accuracy (API 34, includes geoid model error) over the pre-conversion ellipsoidal vertical accuracy, both in the details panel's accuracy row and as the weighting/settle input, falling back to vertical accuracy when MSL accuracy isn't available.

## Test plan
- [x] `./gradlew build` (unit tests, accessibility lint, debug + release assembly) passes
- [x] Extended `ElevationServiceTest`, `ElevationSessionTest`, `DetailsPanelPresenterTest`, `LocationAccuracyTest`, `ReadingStateTest` for the new weighting, window size, and accuracy-preference behavior