### PR TITLE
fix: give details panel rows their own accessibility nodes

### DIFF
--- a/app/src/main/java/com/bizzarosn/heightmark/DetailsPanelPresenter.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/DetailsPanelPresenter.kt
@@ -77,8 +77,10 @@ object DetailsPanelPresenter {
             rows += Row(
                 R.string.detail_fix_age,
                 listOf(
-                    (input.nowElapsedRealtimeNanos - location.elapsedRealtimeNanos) /
-                        NANOS_PER_SECOND
+                    fixAgeSeconds(
+                        (input.nowElapsedRealtimeNanos - location.elapsedRealtimeNanos) /
+                            NANOS_PER_SECOND
+                    )
                 )
             )
         }
@@ -107,7 +109,23 @@ object DetailsPanelPresenter {
     private fun Double.fmt(locale: Locale, decimals: Int): String =
         String.format(locale, "%.${decimals}f", this)
 
+    /**
+     * Below [FIX_AGE_COARSEN_THRESHOLD_S] the exact second is reported; beyond
+     * it the value snaps to [FIX_AGE_STEP_S]-second steps. A 1 Hz ticker keeps
+     * this row's fix age moving, so an unthrottled value would rewrite the
+     * row's accessibility node every second, permanently interrupting anyone
+     * reading it with a screen reader.
+     */
+    private fun fixAgeSeconds(exactSeconds: Long): Long =
+        if (exactSeconds < FIX_AGE_COARSEN_THRESHOLD_S) {
+            exactSeconds
+        } else {
+            (exactSeconds / FIX_AGE_STEP_S) * FIX_AGE_STEP_S
+        }
+
     private const val NANOS_PER_SECOND = 1_000_000_000
     private const val POSITION_DECIMALS = 5
     private const val PRESSURE_DECIMALS = 1
+    private const val FIX_AGE_COARSEN_THRESHOLD_S = 10L
+    private const val FIX_AGE_STEP_S = 10L
 }

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
@@ -42,7 +42,7 @@ class ElevationFragment : Fragment() {
     private lateinit var elevationTextView: TextView
     private lateinit var stabilityLine: StabilityLineView
     private lateinit var detailsToggle: TextView
-    private lateinit var detailsPanel: TextView
+    private lateinit var detailsPanel: ViewGroup
 
     private var useMetricUnit = true
     private var showDetails = false
@@ -192,6 +192,13 @@ class ElevationFragment : Fragment() {
             .start()
     }
 
+    /**
+     * Renders each [DetailsPanelPresenter.Row] as its own child TextView,
+     * recycled across calls and updated only where the resolved text
+     * changed — so a screen reader mid-readout on an untouched row never
+     * has that row's node rewritten under it, and the 1 Hz fix-age ticker
+     * invalidates only the one row it affects.
+     */
     private fun renderDetails(facts: ElevationUiState.DetailsFacts?) {
         if (facts == null) return
         val rows = DetailsPanelPresenter.rows(
@@ -207,8 +214,20 @@ class ElevationFragment : Fragment() {
                 locale = Locale.getDefault()
             )
         )
-        detailsPanel.text = rows.joinToString("\n") { resolve(it) }
+        rows.forEachIndexed { index, row ->
+            val text = resolve(row)
+            val rowView = detailsPanel.getChildAt(index) as? TextView
+                ?: createDetailsRowView().also { detailsPanel.addView(it, index) }
+            if (rowView.text != text) rowView.text = text
+        }
+        while (detailsPanel.childCount > rows.size) {
+            detailsPanel.removeViewAt(detailsPanel.childCount - 1)
+        }
     }
+
+    private fun createDetailsRowView(): TextView =
+        LayoutInflater.from(requireContext())
+            .inflate(R.layout.item_detail_row, detailsPanel, false) as TextView
 
     /** Resolves a presenter row, flattening the one nested length resource. */
     private fun resolve(row: DetailsPanelPresenter.Row): String {

--- a/app/src/main/res/layout/fragment_elevation.xml
+++ b/app/src/main/res/layout/fragment_elevation.xml
@@ -99,16 +99,19 @@
             android:text="@string/details_show"
             android:textColor="@color/hm_on_scrim_secondary" />
 
-        <TextView
+        <!--
+             match_parent, not wrap_content: a wrap_content row set re-measures
+             its width as digit counts change (e.g. the fix-age row ticking
+             from 9s to 10s), nudging this centered panel sideways every
+             render. Each row is added as its own child at runtime.
+        -->
+        <LinearLayout
             android:id="@+id/details_panel"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
-            android:fontFamily="monospace"
-            android:textAppearance="?attr/textAppearanceBodySmall"
-            android:textColor="@color/hm_on_scrim_secondary"
+            android:orientation="vertical"
             android:visibility="gone"
-            tools:text="Sea-level elevation: 112.4 m"
             tools:visibility="visible" />
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_detail_row.xml
+++ b/app/src/main/res/layout/item_detail_row.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     One row of the diagnostic panel. A standalone leaf view, so each row
+     surfaces as its own accessibility node and TalkBack can navigate the
+     panel row by row instead of hearing it as one block.
+-->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:fontFamily="monospace"
+    android:textAppearance="?attr/textAppearanceBodySmall"
+    android:textColor="@color/hm_on_scrim_secondary" />

--- a/app/src/test/java/com/bizzarosn/heightmark/DetailsPanelPresenterTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/DetailsPanelPresenterTest.kt
@@ -86,7 +86,8 @@ class DetailsPanelPresenterTest {
                 Row(R.string.detail_geoid_offset, listOf(meters("37.6"))),
                 Row(R.string.detail_accuracy, listOf(meters("3.0"), meters("5.0"))),
                 Row(R.string.detail_position, listOf("47.61000", "-122.33000")),
-                Row(R.string.detail_fix_age, listOf(12L)),
+                // Fix age coarsens above 10s; see the dedicated tests below
+                Row(R.string.detail_fix_age, listOf(10L)),
                 Row(R.string.detail_satellites, listOf(7, 11)),
                 Row(R.string.detail_pressure, listOf("1013.2")),
                 Row(R.string.detail_readings, listOf(10))
@@ -179,5 +180,37 @@ class DetailsPanelPresenterTest {
             .first { it.templateRes == R.string.detail_fix_age }
 
         assertEquals(listOf(1L), age.args)
+    }
+
+    @Test
+    fun `fix age below ten seconds reports the exact second`() {
+        val location = TestLocations.detailsFix(atNanos = 0L)
+
+        val age = DetailsPanelPresenter.rows(input(location = location, nowNanos = 9_000_000_000L))
+            .first { it.templateRes == R.string.detail_fix_age }
+
+        assertEquals(listOf(9L), age.args)
+    }
+
+    /**
+     * A 1 Hz ticker keeps this row's fix age moving; snapping to ten-second
+     * steps past the threshold means the row's text — and the accessibility
+     * node built from it — settles for nine seconds out of every ten instead
+     * of rewriting on every tick.
+     */
+    @Test
+    fun `fix age at or beyond ten seconds snaps to ten-second steps`() {
+        val location = TestLocations.detailsFix(atNanos = 0L)
+
+        fun ageAt(nowNanos: Long) =
+            DetailsPanelPresenter.rows(input(location = location, nowNanos = nowNanos))
+                .first { it.templateRes == R.string.detail_fix_age }
+                .args
+                .single()
+
+        assertEquals(10L, ageAt(10_000_000_000L))
+        assertEquals(10L, ageAt(15_000_000_000L))
+        assertEquals(10L, ageAt(19_000_000_000L))
+        assertEquals(20L, ageAt(20_000_000_000L))
     }
 }


### PR DESCRIPTION
## Summary
- The details panel joined ~10 diagnostic lines into a single TextView, so TalkBack read it as one unreadable block with no row-by-row navigation.
- The 1 Hz fix-age ticker rewrote that entire node every second, making the block effectively unfinishable under a screen reader.
- Split the panel into one recycled TextView per row (`ElevationFragment.renderDetails`), diffed by index so unchanged rows never have their text — and accessibility node — rewritten.
- Coarsened fix age in `DetailsPanelPresenter` to exact seconds below 10s, then 10-second steps beyond that, further cutting ticker-driven churn.
- Made the panel container `match_parent` width instead of `wrap_content` so digit-count changes no longer shift the centered panel sideways.

## Test plan
- [x] `./gradlew build` (lint incl. accessibility-as-error, unit tests, debug+release assembly) — passes
- [x] `./gradlew testDebugUnitTest --tests DetailsPanelPresenterTest` — passes, including new fix-age coarsening boundary tests
- [ ] `./gradlew connectedAndroidTest` — not run here (no emulator available in this environment); `ElevationFragmentTest.detailsPanelSurvivesRepeatedToggling` still targets `R.id.details_panel` by ID and should pass unchanged, but needs confirming on a device/emulator or in CI