### PR TITLE
ci: harden GitHub Actions workflows against supply-chain attacks

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -7,12 +7,6 @@ on:
   # need the same quality gates as PRs targeting main
   pull_request:
 
-permissions:
-  contents: read
-  security-events: write
-  checks: write
-  pull-requests: write
-
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=4 -Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dkotlin.incremental=false -Dorg.gradle.configuration-cache=true
 
@@ -21,12 +15,15 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-        
+
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -43,6 +40,10 @@ jobs:
   build-and-test:
     name: Build, Lint & Unit Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     outputs:
       apk-path: ${{ steps.build.outputs.apk-path }}
     steps:
@@ -64,16 +65,6 @@ jobs:
         with:
           cache-read-only: false
 
-      - name: Cache Android SDK
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.android/sdk
-            ~/.android/build-cache
-          key: android-sdk-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            android-sdk-${{ runner.os }}-
-
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
@@ -87,7 +78,7 @@ jobs:
           echo "apk-path=app/build/outputs/apk/debug/*.apk" >> $GITHUB_OUTPUT
         
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         if: always()
         with:
           files: |
@@ -97,7 +88,7 @@ jobs:
           comment_mode: always
           
       - name: Report Android Lint Results
-        uses: yutailang0119/action-android-lint@v5
+        uses: yutailang0119/action-android-lint@8345a8dece583030445b0b5f9611209431d601c4 # v5
         if: always()
         with:
           report-path: app/build/reports/lint-results-debug.xml
@@ -113,6 +104,8 @@ jobs:
     name: Instrumented Tests
     runs-on: ubuntu-latest
     needs: build-and-test
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -155,7 +148,7 @@ jobs:
             
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
         with:
           api-level: 35
           target: google_apis
@@ -169,7 +162,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
           
       - name: Run instrumented tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
         with:
           api-level: 35
           target: google_apis

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,14 +67,12 @@ jobs:
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > app/release.keystore
 
-      - name: Setup signing environment
-        run: |
-          echo "KEYSTORE_FILE=release.keystore" >> $GITHUB_ENV
-          echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
-          echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> $GITHUB_ENV
-          echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> $GITHUB_ENV
-
       - name: Build release AAB
+        env:
+          KEYSTORE_FILE: release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
           ./gradlew bundleRelease \
             -PversionName=${{ steps.version.outputs.name }} \
@@ -86,7 +84,7 @@ jobs:
         run: rm -f app/release.keystore
 
       - name: Upload AAB to Play Store
-        uses: r0adkll/upload-google-play@v1.1.5
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           packageName: com.bizzarosn.heightmark


### PR DESCRIPTION
## Summary
- SHA-pin third-party actions (`trivy-action`, `publish-unit-test-result-action`, `action-android-lint`, `android-emulator-runner`, `upload-google-play`) so a compromised mutable tag can't silently run in CI or the signed Play Store release job — the mechanism behind the March 2025 tj-actions attack. Versions are unchanged; each pin includes a `# vX.Y.Z` comment and Dependabot already maintains these automatically.
- Step-scope the release signing secrets (`KEYSTORE_FILE`/`KEYSTORE_PASSWORD`/`KEY_ALIAS`/`KEY_PASSWORD`) to only the `bundleRelease` step that consumes them, instead of exporting them to `$GITHUB_ENV` where every later step — including the third-party Play Store upload action — could read them.
- Scope job permissions to least privilege per job instead of granting `security-events:write`, `checks:write`, and `pull-requests:write` workflow-wide to all three `android_build.yml` jobs.
- Drop the no-op "Cache Android SDK" step — neither `~/.android/sdk` nor `~/.android/build-cache` exist on `ubuntu-latest` runners.

## Test plan
- [x] `actionlint` on both workflow files — clean
- [x] `act push -j build-and-test --container-architecture linux/amd64 --dryrun` — job succeeds, SHA-pinned actions resolve correctly
- [x] `release.yml` is `workflow_run`-triggered (doesn't run via `act push`) — validated via `actionlint` and manual review