### PR TITLE
fix: gate idle-wake fixes on reported accuracy

### DIFF
--- a/app/src/main/java/com/bizzarosn/heightmark/IdleWakeMonitor.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/IdleWakeMonitor.kt
@@ -152,10 +152,7 @@ class IdleWakeMonitor @Inject constructor(
 
     private fun onOpportunisticFix(location: Location) {
         val anchor = anchor ?: return
-        val movedHorizontally = anchor.distanceTo(location) > MAX_IDLE_DRIFT_METERS
-        val movedVertically = anchor.hasAltitude() && location.hasAltitude() &&
-            kotlin.math.abs(anchor.altitude - location.altitude) > MAX_IDLE_ALTITUDE_DRIFT_METERS
-        if (movedHorizontally || movedVertically) {
+        if (IdleWakePolicy.shouldWake(anchor, location)) {
             Log.d(TAG, "Opportunistic fix shows movement")
             wake()
         }
@@ -166,7 +163,5 @@ class IdleWakeMonitor @Inject constructor(
         private const val PRESSURE_SAMPLING_PERIOD_US = 1_000_000 // 1 Hz
         private const val PASSIVE_INTERVAL_MS = 10_000L
         private const val FALLBACK_POLL_INTERVAL_MS = 180_000L // 3 min
-        private const val MAX_IDLE_DRIFT_METERS = 30f
-        private const val MAX_IDLE_ALTITUDE_DRIFT_METERS = 10.0
     }
 }

--- a/app/src/main/java/com/bizzarosn/heightmark/IdleWakePolicy.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/IdleWakePolicy.kt
@@ -1,0 +1,53 @@
+package com.bizzarosn.heightmark
+
+import android.location.Location
+import kotlin.math.abs
+
+/**
+ * Decides whether an opportunistic fix — passive-provider or fallback-poll —
+ * proves the device moved while [IdleWakeMonitor] is idle.
+ *
+ * The passive provider relays every other app's fixes, un-coarsened once this
+ * app holds fine location: a cell-tower or Wi-Fi fix routinely reports
+ * hundreds of meters of "movement" that is really just its own error. Each
+ * test below is gated by its own accuracy report — a fix with none, or one
+ * worse than the threshold, cannot prove that axis moved at all — and a fix
+ * that clears the gate must still beat the drift threshold *plus* its
+ * accuracy radius, not the raw threshold alone.
+ *
+ * A false wake self-corrects once the GPS radio confirms nothing moved; a
+ * missed wake only leaves the displayed elevation stale until the next
+ * trigger. Tuned to lean toward the cheaper mistake — reject the fix, not
+ * the movement.
+ */
+object IdleWakePolicy {
+
+    /** True if [location] shows movement from [anchor] worth waking the GPS radio for. */
+    fun shouldWake(anchor: Location, location: Location): Boolean =
+        movedHorizontally(anchor, location) || movedVertically(anchor, location)
+
+    private fun movedHorizontally(anchor: Location, location: Location): Boolean {
+        val accuracy = location.horizontalAccuracyOrNull() ?: return false
+        if (accuracy > MAX_FIX_HORIZONTAL_ACCURACY_M) return false
+        return anchor.distanceTo(location) > MAX_IDLE_DRIFT_METERS + accuracy
+    }
+
+    private fun movedVertically(anchor: Location, location: Location): Boolean {
+        if (!anchor.hasAltitude() || !location.hasAltitude()) return false
+        val accuracy = location.verticalAccuracyOrNull() ?: return false
+        if (accuracy > MAX_FIX_VERTICAL_ACCURACY_M) return false
+        return abs(anchor.altitude - location.altitude) > MAX_IDLE_ALTITUDE_DRIFT_METERS
+    }
+
+    /** Horizontal drift beyond this, past the fix's own accuracy radius, counts as movement. */
+    const val MAX_IDLE_DRIFT_METERS = 30f
+
+    /** Altitude change beyond this counts as vertical movement. */
+    const val MAX_IDLE_ALTITUDE_DRIFT_METERS = 10.0
+
+    /** A horizontal accuracy worse than this (cell-tower fixes) can't reliably clear the drift threshold. */
+    const val MAX_FIX_HORIZONTAL_ACCURACY_M = 50f
+
+    /** A vertical accuracy worse than this leaves too little margin under the altitude-drift threshold. */
+    const val MAX_FIX_VERTICAL_ACCURACY_M = 5.0
+}

--- a/app/src/test/java/com/bizzarosn/heightmark/IdleWakePolicyTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/IdleWakePolicyTest.kt
@@ -1,0 +1,90 @@
+package com.bizzarosn.heightmark
+
+import com.bizzarosn.heightmark.TestLocations.idleWakeFix
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IdleWakePolicyTest {
+
+    @Test
+    fun `fix within drift and accuracy does not wake`() {
+        val anchor = idleWakeFix(driftMeters = 10f)
+        val fix = idleWakeFix(horizontalAccuracy = 5f)
+
+        assertFalse(IdleWakePolicy.shouldWake(anchor, fix))
+    }
+
+    @Test
+    fun `coarse fix with large apparent drift but bad accuracy does not wake`() {
+        // A cell-tower fix: hundreds of meters of "movement" that is really its own error
+        val anchor = idleWakeFix(driftMeters = 300f)
+        val fix = idleWakeFix(horizontalAccuracy = 300f)
+
+        assertFalse(IdleWakePolicy.shouldWake(anchor, fix))
+    }
+
+    @Test
+    fun `fix with no horizontal accuracy does not wake on apparent drift`() {
+        val anchor = idleWakeFix(driftMeters = 100f)
+        val fix = idleWakeFix(horizontalAccuracy = null)
+
+        assertFalse(IdleWakePolicy.shouldWake(anchor, fix))
+    }
+
+    @Test
+    fun `accurate fix beyond drift plus accuracy wakes`() {
+        val anchor = idleWakeFix(driftMeters = 45f)
+        val fix = idleWakeFix(horizontalAccuracy = 5f) // 30 + 5 = 35 < 45
+
+        assertTrue(IdleWakePolicy.shouldWake(anchor, fix))
+    }
+
+    @Test
+    fun `accurate fix within drift plus accuracy margin does not wake`() {
+        val anchor = idleWakeFix(driftMeters = 32f)
+        val fix = idleWakeFix(horizontalAccuracy = 5f) // 30 + 5 = 35, not exceeded
+
+        assertFalse(IdleWakePolicy.shouldWake(anchor, fix))
+    }
+
+    @Test
+    fun `vertical movement with good vertical accuracy wakes`() {
+        val anchor = idleWakeFix(driftMeters = 0f, altitude = 100.0)
+        val fix = idleWakeFix(altitude = 115.0, verticalAccuracy = 2f) // delta 15 > 10
+
+        assertTrue(IdleWakePolicy.shouldWake(anchor, fix))
+    }
+
+    @Test
+    fun `vertical movement without vertical accuracy does not wake`() {
+        val anchor = idleWakeFix(driftMeters = 0f, altitude = 100.0)
+        val fix = idleWakeFix(altitude = 115.0, verticalAccuracy = null)
+
+        assertFalse(IdleWakePolicy.shouldWake(anchor, fix))
+    }
+
+    @Test
+    fun `vertical movement with poor vertical accuracy does not wake`() {
+        val anchor = idleWakeFix(driftMeters = 0f, altitude = 100.0)
+        val fix = idleWakeFix(altitude = 115.0, verticalAccuracy = 8f) // worse than 5 m threshold
+
+        assertFalse(IdleWakePolicy.shouldWake(anchor, fix))
+    }
+
+    @Test
+    fun `missing altitude on either fix skips the vertical test`() {
+        val anchor = idleWakeFix(driftMeters = 0f, hasAltitude = false)
+        val fix = idleWakeFix(altitude = 200.0, verticalAccuracy = 1f)
+
+        assertFalse(IdleWakePolicy.shouldWake(anchor, fix))
+    }
+
+    @Test
+    fun `stationary fix with no accuracies at all does not wake`() {
+        val anchor = idleWakeFix(driftMeters = 0f)
+        val fix = idleWakeFix(horizontalAccuracy = null, verticalAccuracy = null)
+
+        assertFalse(IdleWakePolicy.shouldWake(anchor, fix))
+    }
+}

--- a/app/src/test/java/com/bizzarosn/heightmark/TestLocations.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/TestLocations.kt
@@ -55,6 +55,30 @@ object TestLocations {
         return location
     }
 
+    /**
+     * A fix for [IdleWakePolicy] tests. [driftMeters] only matters when this
+     * fix plays the anchor role: distanceTo is only ever called with the
+     * anchor as receiver, so model the anchor's drift parameter as its
+     * distance to everything, same convention as [movingFix].
+     */
+    fun idleWakeFix(
+        driftMeters: Float = 0f,
+        horizontalAccuracy: Float? = null,
+        hasAltitude: Boolean = true,
+        altitude: Double = 100.0,
+        verticalAccuracy: Float? = null
+    ): Location {
+        val location = mockk<Location>()
+        every { location.distanceTo(any()) } returns driftMeters
+        every { location.hasAccuracy() } returns (horizontalAccuracy != null)
+        horizontalAccuracy?.let { every { location.accuracy } returns it }
+        every { location.hasAltitude() } returns hasAltitude
+        every { location.altitude } returns altitude
+        every { location.hasVerticalAccuracy() } returns (verticalAccuracy != null)
+        verticalAccuracy?.let { every { location.verticalAccuracyMeters } returns it }
+        return location
+    }
+
     /** A fix carrying altitude data for geoid-conversion tests. */
     fun altitudeFix(ellipsoid: Double, msl: Double? = null): Location {
         val location = mockk<Location>()


### PR DESCRIPTION
## Summary
- Passive-provider and fallback-poll fixes reaching `IdleWakeMonitor` had no accuracy check, so a cell-tower or Wi-Fi/fused fix from another app routinely reported enough apparent drift to trip a spurious GPS wake while the device was actually stationary — discarding the settled averaging window and running the GPS radio for ≥30s each time.
- Extracts the wake decision into a pure, JVM-testable `IdleWakePolicy`: horizontal and vertical movement are each gated by their own reported accuracy (a fix with none, or worse than ~50m/5m, can't prove that axis moved), and a fix that clears the gate must still beat the drift threshold plus its accuracy radius — so genuine movement still wakes reliably.
- `IdleWakeMonitor` now just delegates to `IdleWakePolicy.shouldWake(anchor, location)`.

## Test plan
- [x] New `IdleWakePolicyTest` (10 cases): in-bounds fix, coarse/cell-tower fix with large apparent drift but bad accuracy, accuracy-less fix, accurate fix beyond/within the drift+accuracy margin, vertical movement with good/poor/missing vertical accuracy, missing altitude, no accuracies at all.
- [x] `./gradlew build` (unit tests + lint + debug/release APKs) passes.