### PR TITLE
fix: stop the location-off dialog reappearing after it is dismissed

### DIFF
--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
@@ -227,13 +227,20 @@ class ElevationFragment : Fragment() {
             return
         }
         if (locationOffDialog?.isShowing == true) return
+        // Every way the user can close this reports back, so the state stops
+        // asking; the dismissal in onPause deliberately does not, leaving the
+        // question standing for whenever the screen comes back
         locationOffDialog = AlertDialog.Builder(requireContext())
             .setTitle(getString(R.string.location_services_off))
             .setMessage(getString(R.string.location_services_off_message))
             .setPositiveButton(getString(R.string.open_location_settings)) { _, _ ->
+                tracker.onLocationPromptAnswered()
                 startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
             }
-            .setNegativeButton(android.R.string.cancel, null)
+            .setNegativeButton(android.R.string.cancel) { _, _ ->
+                tracker.onLocationPromptAnswered()
+            }
+            .setOnCancelListener { tracker.onLocationPromptAnswered() }
             .create()
         locationOffDialog?.show()
     }

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationTracker.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationTracker.kt
@@ -60,6 +60,7 @@ class ElevationTracker @Inject constructor(
     private val _uiState = MutableStateFlow(
         ElevationUiState.derive(
             blocked = null,
+            locationPromptAnswered = false,
             searchTimedOut = false,
             elevationMeters = null,
             readingState = ReadingState.Acquiring,
@@ -78,6 +79,7 @@ class ElevationTracker @Inject constructor(
     private var searchTimeoutJob: Job? = null
 
     private var blocked: ElevationUiState.Blocked? = null
+    private var locationPromptAnswered = false
     private var searchTimedOut = false
     private var detailsVisible = false
     private var foreground = false
@@ -107,6 +109,16 @@ class ElevationTracker @Inject constructor(
             is LocationPermissionState.RequiresRationale ->
                 block(ElevationUiState.Blocked.PermissionRequired)
         }
+    }
+
+    /**
+     * The user answered the location-services prompt, either way. The screen
+     * keeps saying that tracking is off, but it stops asking until the block
+     * clears and a later one raises the question again.
+     */
+    fun onLocationPromptAnswered() {
+        locationPromptAnswered = true
+        publish()
     }
 
     /** The host became visible: everything that costs power starts here. */
@@ -186,7 +198,7 @@ class ElevationTracker @Inject constructor(
             return
         }
 
-        blocked = null
+        updateBlocked(null)
         startSearchTimeout()
         publish()
     }
@@ -260,9 +272,22 @@ class ElevationTracker @Inject constructor(
 
     /** Records why tracking cannot run and tears down whatever was running. */
     private fun block(reason: ElevationUiState.Blocked) {
-        blocked = reason
+        updateBlocked(reason)
         stopLocationUpdates()
         publish()
+    }
+
+    /**
+     * The only writer of [blocked], because answering the settings prompt only
+     * silences the block that raised it. Anything else — tracking resumed, a
+     * different block — is a new situation, so the prompt is armed again; GPS
+     * still being off is not, and re-blocking for that reason keeps it silent.
+     */
+    private fun updateBlocked(reason: ElevationUiState.Blocked?) {
+        if (reason != ElevationUiState.Blocked.LocationServicesOff) {
+            locationPromptAnswered = false
+        }
+        blocked = reason
     }
 
     private fun isGpsAvailable(): Boolean {
@@ -292,6 +317,7 @@ class ElevationTracker @Inject constructor(
     private fun publish() {
         _uiState.value = ElevationUiState.derive(
             blocked = blocked,
+            locationPromptAnswered = locationPromptAnswered,
             searchTimedOut = searchTimedOut,
             elevationMeters = session.displayedElevationMeters,
             readingState = session.readingState(),

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationUiState.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationUiState.kt
@@ -19,7 +19,12 @@ data class ElevationUiState(
      * alongside it would contradict each other, so hosts hide the line.
      */
     val readingState: ReadingState?,
-    /** Set only for [Blocked.LocationServicesOff], the one block a user can fix. */
+    /**
+     * Set only for [Blocked.LocationServicesOff], the one block a user can fix,
+     * and only until they have answered it. It is a question being asked, not a
+     * property of being blocked: a host renders it as a dialog, and a dialog the
+     * user has already closed must not come back on its own.
+     */
     val promptLocationSettings: Boolean,
     /** Null while the diagnostic panel is closed; nothing feeds it then. */
     val details: DetailsFacts?
@@ -65,9 +70,17 @@ data class ElevationUiState(
          * because that reading is no longer being kept current. Otherwise the
          * last committed elevation wins, and the search text only appears while
          * there has never been one.
+         *
+         * [locationPromptAnswered] silences the settings prompt for as long as
+         * this occurrence of the block lasts. Without it the ask would ride on
+         * every emission, and the diagnostic panel's ticker alone republishes
+         * once a second — enough to put a dismissed dialog straight back up.
+         * The hero still carries the block's message either way, so silencing
+         * the ask never hides why tracking stopped.
          */
         fun derive(
             blocked: Blocked?,
+            locationPromptAnswered: Boolean,
             searchTimedOut: Boolean,
             elevationMeters: Double?,
             readingState: ReadingState,
@@ -76,7 +89,8 @@ data class ElevationUiState(
             ElevationUiState(
                 hero = Hero.Status(blocked.messageRes),
                 readingState = null,
-                promptLocationSettings = blocked == Blocked.LocationServicesOff,
+                promptLocationSettings =
+                    blocked == Blocked.LocationServicesOff && !locationPromptAnswered,
                 details = details
             )
         } else {

--- a/app/src/test/java/com/bizzarosn/heightmark/ElevationUiStateTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/ElevationUiStateTest.kt
@@ -2,6 +2,7 @@ package com.bizzarosn.heightmark
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -14,16 +15,28 @@ class ElevationUiStateTest {
 
     private fun derive(
         blocked: ElevationUiState.Blocked? = null,
+        locationPromptAnswered: Boolean = false,
         searchTimedOut: Boolean = false,
         elevationMeters: Double? = null,
         readingState: ReadingState = ReadingState.Stable,
         details: ElevationUiState.DetailsFacts? = null
     ) = ElevationUiState.derive(
         blocked = blocked,
+        locationPromptAnswered = locationPromptAnswered,
         searchTimedOut = searchTimedOut,
         elevationMeters = elevationMeters,
         readingState = readingState,
         details = details
+    )
+
+    private fun facts(nowElapsedRealtimeNanos: Long = 0L) = ElevationUiState.DetailsFacts(
+        isIdle = false,
+        location = null,
+        nowElapsedRealtimeNanos = nowElapsedRealtimeNanos,
+        satellitesUsed = 3,
+        satellitesVisible = 9,
+        pressureHpa = null,
+        readingCount = 4
     )
 
     @Test
@@ -97,18 +110,45 @@ class ElevationUiStateTest {
     }
 
     @Test
+    fun `an answered prompt stops being asked while the block stands`() {
+        val state = derive(
+            blocked = ElevationUiState.Blocked.LocationServicesOff,
+            locationPromptAnswered = true
+        )
+        assertFalse(state.promptLocationSettings)
+        // Only the ask goes away; the screen still says why tracking stopped
+        assertEquals(
+            ElevationUiState.Hero.Status(R.string.location_services_off),
+            state.hero
+        )
+    }
+
+    @Test
+    fun `the panel ticker cannot revive an answered prompt`() {
+        // The panel restamps its clock every second, so consecutive states are
+        // never equal and a host sees every one of them. That is what used to
+        // put a dismissed dialog straight back up, so the silence has to hold
+        // across distinct emissions rather than rely on deduplication.
+        val first = derive(
+            blocked = ElevationUiState.Blocked.LocationServicesOff,
+            locationPromptAnswered = true,
+            details = facts(nowElapsedRealtimeNanos = 1_000_000_000L)
+        )
+        val second = derive(
+            blocked = ElevationUiState.Blocked.LocationServicesOff,
+            locationPromptAnswered = true,
+            details = facts(nowElapsedRealtimeNanos = 2_000_000_000L)
+        )
+        assertNotEquals(first, second)
+        assertFalse(first.promptLocationSettings)
+        assertFalse(second.promptLocationSettings)
+    }
+
+    @Test
     fun `the diagnostic panel keeps its rows while blocked`() {
         // The panel is how a user sees why tracking stopped, so a block must
         // not blank it out
-        val facts = ElevationUiState.DetailsFacts(
-            isIdle = false,
-            location = null,
-            nowElapsedRealtimeNanos = 0L,
-            satellitesUsed = 3,
-            satellitesVisible = 9,
-            pressureHpa = null,
-            readingCount = 4
-        )
+        val facts = facts()
         assertEquals(
             facts,
             derive(


### PR DESCRIPTION
## The bug

With location services off and the diagnostic panel open, cancelling the "Location Is Off" dialog brought it straight back, about once a second, indefinitely.

`promptLocationSettings` described *being blocked* — a level that stays true — but the fragment renders it as a dialog, which is an edge. Closing a dialog changes the view without changing the model, so every re-assertion of the level rebuilt it.

It needed the panel open because that is what defeats deduplication: the panel's 1 Hz ticker restamps `nowElapsedRealtimeNanos` on each publish, so consecutive states are never equal and the `StateFlow` forwards all of them. The panel's visibility is persisted, so users who leave it open met this on every launch.

## The fix

The flag now means "there is a question outstanding", not "location is off".

- **ElevationUiState** — `derive` takes `locationPromptAnswered`; the prompt is `blocked == LocationServicesOff && !answered`. The hero still carries the block's message, so silencing the ask never hides why tracking stopped.
- **ElevationTracker** — owns the answered bit behind `onLocationPromptAnswered()`. A single `updateBlocked()` is now the only writer of `blocked`, and re-arms the prompt whenever the block becomes anything other than `LocationServicesOff`: off → on → off asks again, while repeated re-blocking for still-off GPS stays silent. Keeping it in the ViewModel means a rotation cannot resurrect a dismissed ask.
- **ElevationFragment** — reports back on all three exits the user chose (both buttons, plus `setOnCancelListener` for back-press and outside tap). The programmatic dismiss in `onPause` deliberately does not report, so backgrounding does not consume the question.

The details ticker stays armed while blocked. Gating it would freeze the fix-age row, which is exactly the diagnostic a blocked user wants; it only made the conflation visible rather than causing it.

## Testing

- `./gradlew build` green — including two new `ElevationUiStateTest` cases: an answered prompt stops being asked while the block stands, and the panel ticker cannot revive one across distinct emissions.
- `./gradlew connectedAndroidTest` green — 14 instrumented tests on an API 36 emulator.
- Reproduced on device before the fix: after Cancel, "Location Is Off" was back at t+1s, t+2s and t+3s. Post-fix I confirmed the dialog still appears correctly under the repro conditions, but could not confirm the post-cancel behaviour on device — Android Studio was running the instrumented suite against the same emulator and repeatedly replaced the APK mid-run. That path is covered by the unit tests.

No instrumented test for the dialog: reaching `LocationServicesOff` needs either a fake `LocationManager` (no `mockk-android` in `androidTest`, and it would mean uninstalling all six `AppModule` bindings) or mutating the emulator's global location setting, which would break the sibling tests that expect GPS available.