### PR TITLE
fix: remove dead bottom nav and add scroll container for short viewports

### DIFF
--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
@@ -9,7 +9,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -71,6 +74,23 @@ class ElevationFragment : Fragment() {
         detailsToggle = view.findViewById(R.id.details_toggle)
         detailsPanel = view.findViewById(R.id.details_panel)
         val unitToggleGroup = view.findViewById<MaterialButtonToggleGroup>(R.id.unit_toggle_group)
+
+        // With the BottomNavigationView gone, nothing else consumes the
+        // navigation-bar inset; the scrim column now absorbs it itself so the
+        // details toggle doesn't end up under the gesture bar.
+        val contentContainer = view.findViewById<View>(R.id.content_container)
+        val initialPaddingLeft = contentContainer.paddingLeft
+        val initialPaddingRight = contentContainer.paddingRight
+        val initialPaddingBottom = contentContainer.paddingBottom
+        ViewCompat.setOnApplyWindowInsetsListener(contentContainer) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updatePadding(
+                left = initialPaddingLeft + systemBars.left,
+                right = initialPaddingRight + systemBars.right,
+                bottom = initialPaddingBottom + systemBars.bottom
+            )
+            insets
+        }
 
         viewLifecycleOwner.lifecycleScope.launch {
             useMetricUnit = preferencesRepository.useMetricUnit.first()

--- a/app/src/main/java/com/bizzarosn/heightmark/MainActivity.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/MainActivity.kt
@@ -4,9 +4,6 @@ import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.ui.setupWithNavController
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -17,10 +14,5 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContentView(R.layout.activity_main)
-
-        val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
-        val navController = navHostFragment.navController
-        val bottomNavigationView = findViewById<BottomNavigationView>(R.id.bottom_navigation)
-        bottomNavigationView.setupWithNavController(navController)
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,21 +12,10 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/bottom_navigation"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:navGraph="@navigation/nav_graph"
         app:defaultNavHost="true"
         android:name="androidx.navigation.fragment.NavHostFragment" />
-
-    <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/bottom_navigation"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom"
-        app:labelVisibilityMode="labeled"
-        app:menu="@menu/bottom_nav_menu"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_elevation.xml
+++ b/app/src/main/res/layout/fragment_elevation.xml
@@ -18,97 +18,112 @@
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/background" />
 
-    <LinearLayout
-        android:id="@+id/content_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@drawable/bg_bottom_scrim"
-        android:gravity="center_horizontal"
-        android:orientation="vertical"
-        android:paddingHorizontal="24dp"
-        android:paddingTop="@dimen/scrim_fade_height"
-        android:paddingBottom="32dp"
+    <ScrollView
+        android:id="@+id/content_scroll"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:fillViewport="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            android:id="@+id/elevation_label"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/current_elevation"
-            android:textAppearance="?attr/textAppearanceLabelLargeEmphasized"
-            android:textColor="@color/hm_on_scrim_secondary" />
-
-        <TextView
-            android:id="@+id/elevation_text_view"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:maxLines="2"
-            android:text="@string/loading_elevation"
-            android:textAppearance="?attr/textAppearanceHeadlineSmall"
-            android:textColor="@color/hm_on_scrim" />
+            android:layout_height="match_parent"
+            android:gravity="bottom"
+            android:orientation="vertical">
 
-        <com.bizzarosn.heightmark.StabilityLineView
-            android:id="@+id/stability_line"
-            android:layout_width="200dp"
-            android:layout_height="24dp"
-            android:layout_marginTop="2dp"
-            android:accessibilityLiveRegion="polite"
-            android:contentDescription="@string/stability_line_a11y" />
-
-        <com.google.android.material.button.MaterialButtonToggleGroup
-            android:id="@+id/unit_toggle_group"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:theme="@style/ThemeOverlay.HeightMark.OnImage"
-            app:selectionRequired="true"
-            app:singleSelection="true">
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/button_meters"
-                style="?attr/materialButtonOutlinedStyle"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:id="@+id/content_container"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:contentDescription="@string/unit_meters_spoken"
-                android:minHeight="@dimen/min_touch_target"
-                android:minWidth="@dimen/unit_chip_min_width"
-                android:text="@string/unit_meters" />
+                android:background="@drawable/bg_bottom_scrim"
+                android:gravity="center_horizontal"
+                android:orientation="vertical"
+                android:paddingHorizontal="24dp"
+                android:paddingTop="@dimen/scrim_fade_height"
+                android:paddingBottom="32dp">
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/button_feet"
-                style="?attr/materialButtonOutlinedStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/unit_feet_spoken"
-                android:minHeight="@dimen/min_touch_target"
-                android:minWidth="@dimen/unit_chip_min_width"
-                android:text="@string/unit_feet" />
-        </com.google.android.material.button.MaterialButtonToggleGroup>
+                <TextView
+                    android:id="@+id/elevation_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/current_elevation"
+                    android:textAppearance="?attr/textAppearanceLabelLargeEmphasized"
+                    android:textColor="@color/hm_on_scrim_secondary" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/details_toggle"
-            style="@style/Widget.Material3.Button.TextButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:minHeight="@dimen/min_touch_target"
-            android:minWidth="@dimen/min_touch_target"
-            android:text="@string/details_show"
-            android:textColor="@color/hm_on_scrim_secondary" />
+                <TextView
+                    android:id="@+id/elevation_text_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:maxLines="2"
+                    android:text="@string/loading_elevation"
+                    android:textAppearance="?attr/textAppearanceHeadlineSmall"
+                    android:textColor="@color/hm_on_scrim" />
 
-        <TextView
-            android:id="@+id/details_panel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:fontFamily="monospace"
-            android:textAppearance="?attr/textAppearanceBodySmall"
-            android:textColor="@color/hm_on_scrim_secondary"
-            android:visibility="gone"
-            tools:text="Sea-level elevation: 112.4 m"
-            tools:visibility="visible" />
-    </LinearLayout>
+                <com.bizzarosn.heightmark.StabilityLineView
+                    android:id="@+id/stability_line"
+                    android:layout_width="200dp"
+                    android:layout_height="24dp"
+                    android:layout_marginTop="2dp"
+                    android:accessibilityLiveRegion="polite"
+                    android:contentDescription="@string/stability_line_a11y" />
+
+                <com.google.android.material.button.MaterialButtonToggleGroup
+                    android:id="@+id/unit_toggle_group"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:theme="@style/ThemeOverlay.HeightMark.OnImage"
+                    app:selectionRequired="true"
+                    app:singleSelection="true">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/button_meters"
+                        style="?attr/materialButtonOutlinedStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/unit_meters_spoken"
+                        android:minHeight="@dimen/min_touch_target"
+                        android:minWidth="@dimen/unit_chip_min_width"
+                        android:text="@string/unit_meters" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/button_feet"
+                        style="?attr/materialButtonOutlinedStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/unit_feet_spoken"
+                        android:minHeight="@dimen/min_touch_target"
+                        android:minWidth="@dimen/unit_chip_min_width"
+                        android:text="@string/unit_feet" />
+                </com.google.android.material.button.MaterialButtonToggleGroup>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/details_toggle"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:minHeight="@dimen/min_touch_target"
+                    android:minWidth="@dimen/min_touch_target"
+                    android:text="@string/details_show"
+                    android:textColor="@color/hm_on_scrim_secondary" />
+
+                <TextView
+                    android:id="@+id/details_panel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:fontFamily="monospace"
+                    android:textAppearance="?attr/textAppearanceBodySmall"
+                    android:textColor="@color/hm_on_scrim_secondary"
+                    android:visibility="gone"
+                    tools:text="Sea-level elevation: 112.4 m"
+                    tools:visibility="visible" />
+            </LinearLayout>
+        </LinearLayout>
+    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-    <item
-        android:id="@+id/elevationFragment"
-        android:icon="@drawable/ic_elevation"
-        android:title="@string/elevation" />
-</menu>


### PR DESCRIPTION
## Summary

- Removes the single-item `BottomNavigationView` (a Material anti-pattern that permanently spent ~80dp) so the `NavHostFragment` fills the screen edge-to-edge.
- Wraps the content column in a `fillViewport` `ScrollView` with bottom gravity: it stays bottom-anchored when content fits, and scrolls instead of clipping when it doesn't (landscape with the details panel open, or large fontScale in portrait).
- The scrim column now absorbs the navigation-bar inset itself via a window insets listener, replacing what the `BottomNavigationView` used to consume implicitly — keeps the details toggle clear of the gesture bar.

## Screenshots

Day/night × portrait/landscape screenshots from the emulator, plus one showing the details panel open in landscape (the originally-clipped scenario), are attached separately for review — will follow in a PR comment.

## Test plan

- [x] `./gradlew build` (lint incl. Accessibility=error, unit tests, assembleDebug, assembleRelease) — passes
- [x] Manually verified on emulator: day/night × portrait/landscape, plus details panel open in landscape (no clipping, scrolls cleanly)
- [ ] `./gradlew connectedAndroidTest` — attempted repeatedly; this dev environment has ~17 concurrent worktree sessions sharing one emulator, causing cross-session interference (global location-setting toggles, package reinstall races). Recommend re-running on a dedicated emulator for a clean signal.