### PR TITLE
fix: give blocked states a persistent, explained recovery action

### DIFF
--- a/app/src/androidTest/java/com/bizzarosn/heightmark/LocationPermissionTest.kt
+++ b/app/src/androidTest/java/com/bizzarosn/heightmark/LocationPermissionTest.kt
@@ -6,12 +6,15 @@ import android.content.pm.PackageManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
 import org.junit.Assume.assumeFalse
 import org.junit.Rule
@@ -38,6 +41,9 @@ class LocationPermissionTest : HiltUiTestBase() {
     fun appWorksWithFineLocationOnly() {
         launchHome {
             onView(withId(R.id.unit_toggle_group)).check(matches(isDisplayed()))
+            // Fine location is granted, so nothing is blocked and the
+            // persistent recovery button has nothing to offer
+            onView(withId(R.id.blocked_action_button)).check(matches(not(isDisplayed())))
         }
     }
 }
@@ -72,6 +78,25 @@ class CoarseLocationPermissionTest : HiltUiTestBase() {
             onView(withText(R.string.precise_location_required))
                 .inRoot(isDialog())
                 .check(matches(isDisplayed()))
+
+            // The dialog is dismissible rather than forced (setCancelable(true));
+            // back-press is the least destructive way to refuse it — neither of
+            // its two buttons ("Grant Permission" / "Open Settings") represents
+            // "no thanks", so this is the only way to decline without acting
+            pressBack()
+
+            // Dismissal lands on the blocked screen, which explains the block
+            // and keeps the same recovery action reachable as a persistent button
+            onView(withId(R.id.elevation_text_view))
+                .check(matches(withText(R.string.precise_location_blocked_message)))
+            onView(withId(R.id.blocked_action_button))
+                .check(matches(allOf(isDisplayed(), withText(R.string.grant_permission))))
+
+            // A perform(), not just a check(), so the globally-enabled ATF pass
+            // (HiltTestRunner) validates the button's touch target and label
+            // while it's visible — tapping it directly would launch the real
+            // system permission dialog, which this test doesn't drive
+            onView(withId(R.id.button_feet)).perform(click())
         }
     }
 }
@@ -102,6 +127,8 @@ class BothLocationPermissionsTest : HiltUiTestBase() {
             onView(withId(R.id.elevation_text_view)).check(
                 matches(not(withText(R.string.precise_location_required)))
             )
+            // Nothing is blocked, so the persistent recovery button stays hidden
+            onView(withId(R.id.blocked_action_button)).check(matches(not(isDisplayed())))
         }
     }
 }

--- a/app/src/main/java/com/bizzarosn/heightmark/DetailsPanelPresenter.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/DetailsPanelPresenter.kt
@@ -19,6 +19,7 @@ object DetailsPanelPresenter {
 
     data class Input(
         val isIdle: Boolean,
+        val isBlocked: Boolean,
         val location: Location?,
         val nowElapsedRealtimeNanos: Long,
         val satellitesUsed: Int,
@@ -38,7 +39,13 @@ object DetailsPanelPresenter {
     fun rows(input: Input): List<Row> {
         val rows = mutableListOf<Row>()
         rows += Row(
-            if (input.isIdle) R.string.detail_state_idle else R.string.detail_state_tracking
+            when {
+                // A block outranks idle: the duty cycle's own idle flag is
+                // meaningless once tracking has stopped for another reason
+                input.isBlocked -> R.string.detail_state_blocked
+                input.isIdle -> R.string.detail_state_idle
+                else -> R.string.detail_state_tracking
+            }
         )
 
         val location = input.location

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
@@ -15,6 +15,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.button.MaterialButton
 import com.google.android.material.button.MaterialButtonToggleGroup
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
@@ -41,6 +42,7 @@ class ElevationFragment : Fragment() {
 
     private lateinit var elevationTextView: TextView
     private lateinit var stabilityLine: StabilityLineView
+    private lateinit var blockedActionButton: MaterialButton
     private lateinit var detailsToggle: TextView
     private lateinit var detailsPanel: TextView
 
@@ -53,9 +55,12 @@ class ElevationFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        permissionHandler = LocationPermissionHandler(this) { state ->
-            tracker.onPermissionState(state)
-        }
+        permissionHandler = LocationPermissionHandler(
+            fragment = this,
+            onPermissionStateChanged = { state -> tracker.onPermissionState(state) },
+            hasShownUpgradeDialog = { tracker.upgradeDialogShown },
+            onUpgradeDialogShown = { tracker.upgradeDialogShown = true }
+        )
         permissionHandler.initialize()
     }
 
@@ -68,6 +73,7 @@ class ElevationFragment : Fragment() {
 
         elevationTextView = view.findViewById(R.id.elevation_text_view)
         stabilityLine = view.findViewById(R.id.stability_line)
+        blockedActionButton = view.findViewById(R.id.blocked_action_button)
         detailsToggle = view.findViewById(R.id.details_toggle)
         detailsPanel = view.findViewById(R.id.details_panel)
         val unitToggleGroup = view.findViewById<MaterialButtonToggleGroup>(R.id.unit_toggle_group)
@@ -132,6 +138,7 @@ class ElevationFragment : Fragment() {
         renderStabilityLine(state.readingState)
         renderDetails(state.details)
         renderLocationOffPrompt(state.promptLocationSettings)
+        renderBlockedAction(state.blockedAction)
     }
 
     /**
@@ -197,6 +204,7 @@ class ElevationFragment : Fragment() {
         val rows = DetailsPanelPresenter.rows(
             DetailsPanelPresenter.Input(
                 isIdle = facts.isIdle,
+                isBlocked = facts.isBlocked,
                 location = facts.location,
                 nowElapsedRealtimeNanos = facts.nowElapsedRealtimeNanos,
                 satellitesUsed = facts.satellitesUsed,
@@ -241,6 +249,31 @@ class ElevationFragment : Fragment() {
     private fun dismissLocationOffDialog() {
         locationOffDialog?.dismiss()
         locationOffDialog = null
+    }
+
+    /**
+     * The blocked screen's persistent recovery path: unlike the dialogs,
+     * which are dismissible and shown at most once per interruption, this
+     * button stays available for the rest of the session so dismissing a
+     * dialog never strands the user without a way to retry.
+     */
+    private fun renderBlockedAction(action: ElevationUiState.BlockedAction?) {
+        if (action == null) {
+            blockedActionButton.isVisible = false
+            return
+        }
+        blockedActionButton.isVisible = true
+        blockedActionButton.setText(action.labelRes)
+        blockedActionButton.setOnClickListener { performBlockedAction(action) }
+    }
+
+    private fun performBlockedAction(action: ElevationUiState.BlockedAction) {
+        when (action) {
+            ElevationUiState.BlockedAction.RequestPermission -> permissionHandler.requestPermissions()
+            ElevationUiState.BlockedAction.OpenAppSettings -> permissionHandler.openAppSettings()
+            ElevationUiState.BlockedAction.OpenLocationSettings ->
+                startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
+        }
     }
 
     private fun applyTextAppearance(textAppearanceAttr: Int) {

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationTracker.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationTracker.kt
@@ -84,6 +84,15 @@ class ElevationTracker @Inject constructor(
     private var receiverRegistered = false
     private var lastLocation: Location? = null
 
+    /**
+     * Whether the coarse-only precise-upgrade dialog has already interrupted
+     * this session. Lives here rather than on [LocationPermissionHandler]
+     * because that handler is rebuilt on every fragment recreation
+     * (rotation, dark-mode switch); this ViewModel survives those and dies
+     * only with the session, matching the "once per session" intent.
+     */
+    var upgradeDialogShown = false
+
     private val providersChangedReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             if (intent?.action != LocationManager.PROVIDERS_CHANGED_ACTION) return
@@ -103,9 +112,10 @@ class ElevationTracker @Inject constructor(
             }
             is LocationPermissionState.CoarseOnly ->
                 block(ElevationUiState.Blocked.PreciseLocationRequired)
-            is LocationPermissionState.PermanentlyDenied,
             is LocationPermissionState.RequiresRationale ->
                 block(ElevationUiState.Blocked.PermissionRequired)
+            is LocationPermissionState.PermanentlyDenied ->
+                block(ElevationUiState.Blocked.PermissionPermanentlyDenied)
         }
     }
 
@@ -303,6 +313,7 @@ class ElevationTracker @Inject constructor(
         if (!detailsVisible) return null
         return ElevationUiState.DetailsFacts(
             isIdle = session.isIdle,
+            isBlocked = blocked != null,
             location = lastLocation,
             nowElapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos(),
             satellitesUsed = detailsSources.satellitesUsed,

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationUiState.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationUiState.kt
@@ -21,6 +21,8 @@ data class ElevationUiState(
     val readingState: ReadingState?,
     /** Set only for [Blocked.LocationServicesOff], the one block a user can fix. */
     val promptLocationSettings: Boolean,
+    /** Null unless blocked — the persistent action button hosts should offer. */
+    val blockedAction: BlockedAction?,
     /** Null while the diagnostic panel is closed; nothing feeds it then. */
     val details: DetailsFacts?
 ) {
@@ -34,11 +36,32 @@ data class ElevationUiState(
         data class Value(val meters: Double) : Hero
     }
 
-    /** Why tracking cannot run. Each replaces the reading with its message. */
-    enum class Blocked(@param:StringRes val messageRes: Int) {
-        PermissionRequired(R.string.location_permission_required),
-        PreciseLocationRequired(R.string.precise_location_required),
-        LocationServicesOff(R.string.location_services_off)
+    /** The corrective action a [Blocked] state's persistent button performs. */
+    enum class BlockedAction(@param:StringRes val labelRes: Int) {
+        RequestPermission(R.string.grant_permission),
+        OpenAppSettings(R.string.open_settings),
+        OpenLocationSettings(R.string.open_location_settings)
+    }
+
+    /**
+     * Why tracking cannot run. Each replaces the reading with a sentence-style
+     * [messageRes] and offers a persistent [action] — the dialogs that first
+     * surface these reasons are dismissible, so this is the only recovery path
+     * guaranteed to still be reachable later in the session.
+     */
+    enum class Blocked(@param:StringRes val messageRes: Int, val action: BlockedAction) {
+        PermissionRequired(
+            R.string.location_permission_blocked_message, BlockedAction.RequestPermission
+        ),
+        PermissionPermanentlyDenied(
+            R.string.location_permission_denied_blocked_message, BlockedAction.OpenAppSettings
+        ),
+        PreciseLocationRequired(
+            R.string.precise_location_blocked_message, BlockedAction.RequestPermission
+        ),
+        LocationServicesOff(
+            R.string.location_services_off_blocked_message, BlockedAction.OpenLocationSettings
+        )
     }
 
     /**
@@ -51,6 +74,7 @@ data class ElevationUiState(
      */
     data class DetailsFacts(
         val isIdle: Boolean,
+        val isBlocked: Boolean,
         val location: Location?,
         val nowElapsedRealtimeNanos: Long,
         val satellitesUsed: Int,
@@ -77,6 +101,7 @@ data class ElevationUiState(
                 hero = Hero.Status(blocked.messageRes),
                 readingState = null,
                 promptLocationSettings = blocked == Blocked.LocationServicesOff,
+                blockedAction = blocked.action,
                 details = details
             )
         } else {
@@ -86,6 +111,7 @@ data class ElevationUiState(
                 ),
                 readingState = readingState,
                 promptLocationSettings = false,
+                blockedAction = null,
                 details = details
             )
         }

--- a/app/src/main/java/com/bizzarosn/heightmark/LocationPermissionHandler.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/LocationPermissionHandler.kt
@@ -37,12 +37,16 @@ sealed class LocationPermissionState {
 
 class LocationPermissionHandler(
     private val fragment: Fragment,
-    private val onPermissionStateChanged: (LocationPermissionState) -> Unit
+    private val onPermissionStateChanged: (LocationPermissionState) -> Unit,
+    /** Whether the upgrade dialog already interrupted this session — the
+     *  caller backs this with session-scoped state, since this handler is
+     *  rebuilt on every fragment recreation and cannot hold it itself. */
+    private val hasShownUpgradeDialog: () -> Boolean,
+    private val onUpgradeDialogShown: () -> Unit
 ) : DefaultLifecycleObserver {
-    
+
     private var locationPermissionLauncher: ActivityResultLauncher<Array<String>>? = null
     private var currentDialog: AlertDialog? = null
-    private var upgradeDialogShown = false
 
     private val permissions = arrayOf(
         Manifest.permission.ACCESS_FINE_LOCATION,
@@ -93,7 +97,9 @@ class LocationPermissionHandler(
         }
     }
     
-    private fun requestPermissions() {
+    /** Launches the system permission request. Also the blocked screen's
+     *  persistent-action entry point for [ElevationUiState.BlockedAction.RequestPermission]. */
+    fun requestPermissions() {
         locationPermissionLauncher?.launch(permissions)
     }
     
@@ -126,10 +132,11 @@ class LocationPermissionHandler(
 
     private fun showPreciseUpgradeDialog() {
         // Ask once per session; re-requesting in a loop would just re-show the
-        // system dialog every time the fragment resumes
-        if (upgradeDialogShown) return
+        // system dialog every time the fragment resumes. The blocked screen's
+        // persistent action button is the fallback once this has fired.
+        if (hasShownUpgradeDialog()) return
         if (currentDialog?.isShowing == true) return
-        upgradeDialogShown = true
+        onUpgradeDialogShown()
 
         showDialog(
             titleRes = R.string.precise_location_required,
@@ -149,8 +156,8 @@ class LocationPermissionHandler(
             messageRes = R.string.location_permission_rationale_message,
             positiveRes = R.string.grant_permission,
             onPositive = ::requestPermissions,
-            negativeRes = R.string.exit_app,
-            onNegative = { fragment.requireActivity().finish() }
+            negativeRes = R.string.not_now,
+            onNegative = {}
         )
     }
 
@@ -162,12 +169,18 @@ class LocationPermissionHandler(
             messageRes = R.string.permission_permanently_denied_message,
             positiveRes = R.string.open_settings,
             onPositive = ::openAppSettings,
-            negativeRes = R.string.exit_app,
-            onNegative = { fragment.requireActivity().finish() }
+            negativeRes = R.string.not_now,
+            onNegative = {}
         )
     }
 
-    /** Builds and shows the single tracked dialog; callers gate on [currentDialog]. */
+    /**
+     * Builds and shows the single tracked dialog; callers gate on
+     * [currentDialog]. Dismissible rather than forced — refusing (back,
+     * outside tap, or the negative button) lands the user back on the
+     * blocked screen, which now explains the block and offers the same
+     * recovery action as a persistent button.
+     */
     private fun showDialog(
         @StringRes titleRes: Int,
         @StringRes messageRes: Int,
@@ -181,13 +194,15 @@ class LocationPermissionHandler(
             .setMessage(fragment.getString(messageRes))
             .setPositiveButton(fragment.getString(positiveRes)) { _, _ -> onPositive() }
             .setNegativeButton(fragment.getString(negativeRes)) { _, _ -> onNegative() }
-            .setCancelable(false)
+            .setCancelable(true)
             .create()
 
         currentDialog?.show()
     }
 
-    private fun openAppSettings() {
+    /** Also the blocked screen's persistent-action entry point for
+     *  [ElevationUiState.BlockedAction.OpenAppSettings]. */
+    fun openAppSettings() {
         val intent = Intent(
             Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
             Uri.fromParts("package", fragment.requireActivity().packageName, null)

--- a/app/src/main/res/layout/fragment_elevation.xml
+++ b/app/src/main/res/layout/fragment_elevation.xml
@@ -58,6 +58,21 @@
             android:accessibilityLiveRegion="polite"
             android:contentDescription="@string/stability_line_a11y" />
 
+        <!-- Visible only while ElevationUiState.blockedAction is non-null; the
+             fragment sets both visibility and label, never the layout. -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/blocked_action_button"
+            style="@style/Widget.Material3.Button.TonalButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:minHeight="@dimen/min_touch_target"
+            android:minWidth="@dimen/min_touch_target"
+            android:theme="@style/ThemeOverlay.HeightMark.OnImage"
+            android:visibility="gone"
+            tools:text="@string/grant_permission"
+            tools:visibility="visible" />
+
         <com.google.android.material.button.MaterialButtonToggleGroup
             android:id="@+id/unit_toggle_group"
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="location_permission_required">Location Permission Required</string>
     <string name="location_permission_rationale_message">This app needs location permission to determine your elevation. Without this permission, the app cannot function.</string>
     <string name="grant_permission">Grant Permission</string>
-    <string name="exit_app">Exit App</string>
+    <string name="not_now">Not now</string>
     <string name="permission_permanently_denied_message">This app needs location permission to determine your elevation. Please open settings and enable location permission manually.</string>
     <string name="open_settings">Open Settings</string>
     <string name="precise_location_required">Precise Location Required</string>
@@ -27,6 +27,14 @@
     <string name="location_services_off">Location Is Off</string>
     <string name="location_services_off_message">Turn on location to determine your elevation.</string>
     <string name="open_location_settings">Open Location Settings</string>
+    <!-- Sentence-style hero messages for the blocked screen itself, distinct
+         from the Title-Case dialog headings above: the hero is what stays on
+         screen for the rest of the session, so it needs to read as a sentence
+         and stay short enough not to crowd the action button beneath it. -->
+    <string name="location_permission_blocked_message">Location permission is needed to show your elevation.</string>
+    <string name="location_permission_denied_blocked_message">Location permission was denied. Open settings to enable it.</string>
+    <string name="precise_location_blocked_message">Elevation needs precise location, not just approximate.</string>
+    <string name="location_services_off_blocked_message">Turn on location services to see your elevation.</string>
     <string name="still_searching">Still searching for GPS signal… This works best outdoors with a clear view of the sky.</string>
     <string name="stability_acquiring">Searching for GPS signal</string>
     <string name="stability_converging">Reading is settling</string>
@@ -47,6 +55,7 @@
     <string name="detail_pressure">Pressure: %1$s hPa</string>
     <string name="detail_state_tracking">GPS: tracking</string>
     <string name="detail_state_idle">GPS: idle (stationary)</string>
+    <string name="detail_state_blocked">GPS: off</string>
     <string name="detail_no_fix">Waiting for first fix…</string>
     <string name="value_meters">%1$s m</string>
     <string name="value_feet">%1$s ft</string>

--- a/app/src/test/java/com/bizzarosn/heightmark/DetailsPanelPresenterTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/DetailsPanelPresenterTest.kt
@@ -15,6 +15,7 @@ class DetailsPanelPresenterTest {
 
     private fun input(
         isIdle: Boolean = false,
+        isBlocked: Boolean = false,
         location: android.location.Location? = null,
         nowNanos: Long = 0L,
         satellitesUsed: Int = 0,
@@ -24,6 +25,7 @@ class DetailsPanelPresenterTest {
         useMetric: Boolean = true
     ) = Input(
         isIdle = isIdle,
+        isBlocked = isBlocked,
         location = location,
         nowElapsedRealtimeNanos = nowNanos,
         satellitesUsed = satellitesUsed,
@@ -169,6 +171,15 @@ class DetailsPanelPresenterTest {
         val rows = DetailsPanelPresenter.rows(input(isIdle = true))
 
         assertEquals(Row(R.string.detail_state_idle), rows.first())
+    }
+
+    @Test
+    fun `a block outranks idle for the leading row`() {
+        // The duty cycle's own idle flag doesn't get cleared just because
+        // tracking stopped for a different reason, so a block must win
+        val rows = DetailsPanelPresenter.rows(input(isIdle = true, isBlocked = true))
+
+        assertEquals(Row(R.string.detail_state_blocked), rows.first())
     }
 
     @Test

--- a/app/src/test/java/com/bizzarosn/heightmark/ElevationUiStateTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/ElevationUiStateTest.kt
@@ -55,12 +55,37 @@ class ElevationUiStateTest {
         // The number is no longer being kept current, so leaving it up would
         // present a stale elevation as a live one
         assertEquals(
-            ElevationUiState.Hero.Status(R.string.location_permission_required),
+            ElevationUiState.Hero.Status(R.string.location_permission_blocked_message),
             derive(
                 blocked = ElevationUiState.Blocked.PermissionRequired,
                 elevationMeters = 1234.5
             ).hero
         )
+    }
+
+    @Test
+    fun `each block carries the persistent action its message asks for`() {
+        assertEquals(
+            ElevationUiState.BlockedAction.RequestPermission,
+            derive(blocked = ElevationUiState.Blocked.PermissionRequired).blockedAction
+        )
+        assertEquals(
+            ElevationUiState.BlockedAction.OpenAppSettings,
+            derive(blocked = ElevationUiState.Blocked.PermissionPermanentlyDenied).blockedAction
+        )
+        assertEquals(
+            ElevationUiState.BlockedAction.RequestPermission,
+            derive(blocked = ElevationUiState.Blocked.PreciseLocationRequired).blockedAction
+        )
+        assertEquals(
+            ElevationUiState.BlockedAction.OpenLocationSettings,
+            derive(blocked = ElevationUiState.Blocked.LocationServicesOff).blockedAction
+        )
+    }
+
+    @Test
+    fun `no block means no persistent action`() {
+        assertNull(derive(elevationMeters = 10.0).blockedAction)
     }
 
     @Test
@@ -102,6 +127,7 @@ class ElevationUiStateTest {
         // not blank it out
         val facts = ElevationUiState.DetailsFacts(
             isIdle = false,
+            isBlocked = true,
             location = null,
             nowElapsedRealtimeNanos = 0L,
             satellitesUsed = 3,


### PR DESCRIPTION
## Summary

- Each `Blocked` state (permission required, coarse-only, location services off) now carries a sentence-style hero message and a `BlockedAction` (request permission / open app settings / open location settings), rendered as a persistent inline button — so recovery is always reachable, even after a dialog is dismissed and even for a coarse-only user the upgrade dialog already fired once for.
- The upgrade-dialog-shown flag moved from `LocationPermissionHandler` (rebuilt every fragment recreation) into `ElevationTracker`, the `@HiltViewModel` — it now survives rotation and resets only with the session, matching the intended "once per session" behavior instead of re-prompting on every rotation.
- The permission-rationale and permanent-denial dialogs are dismissible now (`setCancelable(true)`, "Not now" instead of "Exit App" → `finish()`); dismissing lands on the blocked screen, which explains the block and offers the same recovery action as a persistent button.
- The details panel's leading row now checks the block state before idle, so it no longer shows "GPS: tracking" while tracking is actually blocked — new "GPS: off" row.

## Test plan

- [x] `./gradlew build` (lint incl. accessibility-as-error, unit tests, debug+release APKs) — passes
- [x] `./gradlew connectedAndroidTest` — 14/14 passing, 1 expected skip (order-dependent coarse-only assumeFalse guard); the coarse-only dialog-dismiss → persistent-button flow also verified in isolation