### PR TITLE
fix: repair Android 13+ themed launcher icon

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -5,24 +5,24 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     
-    <!-- Sky gradient background -->
+    <!-- Sky background (hm_tertiary_container) -->
     <path
-        android:fillColor="#87CEEB"
+        android:fillColor="#BCEBF2"
         android:pathData="M0,0h108v108h-108z" />
-    
+
     <!-- Cloud-like subtle background pattern -->
     <path
-        android:fillColor="#B0E0E6"
+        android:fillColor="#FFFFFF"
         android:fillAlpha="0.3"
         android:pathData="M20,25 A8,8 0 1,1 36,25 A6,6 0 1,1 20,25 Z" />
-    
+
     <path
-        android:fillColor="#B0E0E6"
+        android:fillColor="#FFFFFF"
         android:fillAlpha="0.2"
         android:pathData="M70,35 A10,10 0 1,1 90,35 A7,7 0 1,1 70,35 Z" />
-    
+
     <path
-        android:fillColor="#B0E0E6"
+        android:fillColor="#FFFFFF"
         android:fillAlpha="0.25"
         android:pathData="M15,70 A6,6 0 1,1 27,70 A4,4 0 1,1 15,70 Z" />
     

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -4,71 +4,33 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     
-    <!-- Background circle with padding for adaptive icon -->
-    <path
-        android:pathData="M54,20 A34,34 0 1,1 54,88 A34,34 0 1,1 54,20 Z"
-        android:fillColor="#E8F5E8"
-        android:strokeColor="#4CAF50"
-        android:strokeWidth="1.5"/>
-    
     <!-- Back mountain layer -->
     <path
         android:pathData="M26,66 L34,52 L42,60 L50,46 L58,54 L66,66 L66,76 L26,76 Z"
-        android:fillColor="#A5D6A7"
-        android:fillAlpha="0.6"/>
-    
+        android:fillColor="#D4E8D0"
+        android:fillAlpha="0.7"/>
+
     <!-- Middle mountain layer -->
     <path
         android:pathData="M30,70 L38,56 L46,66 L54,50 L62,58 L62,76 L30,76 Z"
-        android:fillColor="#66BB6A"
-        android:fillAlpha="0.8"/>
-    
+        android:fillColor="#516350"
+        android:fillAlpha="0.85"/>
+
     <!-- Main peak -->
     <path
         android:pathData="M36,74 L54,38 L72,74 L72,76 L36,76 Z"
-        android:fillColor="#4CAF50"/>
-    
+        android:fillColor="#38693C"/>
+
     <!-- Peak highlight -->
     <path
         android:pathData="M36,74 L54,38 L63,59 L45,74 Z"
-        android:fillColor="#81C784"/>
-    
+        android:fillColor="#B9F0B8"/>
+
     <!-- GPS location marker at peak -->
     <path
         android:pathData="M54,37.5 A2.5,2.5 0 1,1 54,42.5 A2.5,2.5 0 1,1 54,37.5 Z"
-        android:fillColor="#FF5722"/>
+        android:fillColor="#39656B"/>
     <path
         android:pathData="M54,38.5 A1.5,1.5 0 1,1 54,41.5 A1.5,1.5 0 1,1 54,38.5 Z"
         android:fillColor="#FFFFFF"/>
-    
-    <!-- Elevation measurement lines -->
-    <path
-        android:pathData="M70,74 L78,74"
-        android:strokeColor="#1976D2"
-        android:strokeWidth="1"/>
-    <path
-        android:pathData="M70,58 L76,58"
-        android:strokeColor="#1976D2"
-        android:strokeWidth="1"/>
-    <path
-        android:pathData="M70,40 L74,40"
-        android:strokeColor="#1976D2"
-        android:strokeWidth="1"/>
-    
-    <!-- Vertical measurement line -->
-    <path
-        android:pathData="M71,40 L71,74"
-        android:strokeColor="#1976D2"
-        android:strokeWidth="1"/>
-    
-    <!-- Height indicator arrow -->
-    <path
-        android:pathData="M68,40 L70,40"
-        android:strokeColor="#1976D2"
-        android:strokeWidth="1"/>
-    <path
-        android:pathData="M69,38 L70,40 L69,42"
-        android:strokeColor="#1976D2"
-        android:strokeWidth="1"
-        android:fillColor="#00000000"/>
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <!-- Mountain silhouette, sized to the 66dp adaptive-icon safe zone -->
+    <path
+        android:pathData="M28,80 L38,54 L46,64 L58,26 L72,52 L80,80 Z"
+        android:fillColor="#FF000000"/>
+
+    <!-- Location marker capping the summit -->
+    <path
+        android:pathData="M58,23 A6,6 0 1,1 58,35 A6,6 0 1,1 58,23 Z"
+        android:fillColor="#FF000000"/>
+</vector>

--- a/app/src/main/res/mipmap-anydpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher.xml
@@ -2,5 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
-    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>


### PR DESCRIPTION
## Summary
- `<monochrome>` pointed at the full-color foreground, whose opaque circular plate rendered as a featureless disc under Android 13+'s alpha-mask themed-icon compositing
- Added a dedicated `ic_launcher_monochrome.xml` — a bold mountain + summit-marker alpha silhouette sized to the adaptive-icon safe zone, no plate or hairlines
- Removed the opaque plate and sub-pixel measurement-line strokes from `ic_launcher_foreground.xml`; recolored the mountain/marker art and the sky background from the app's `hm_` palette so the icon, splash, and app read as one brand

## Test plan
- [x] `./gradlew assembleDebug` — vector XML parses, build succeeds
- [x] `./gradlew lintDebug` — no new violations
- [x] Installed on an emulator; confirmed the default/masked adaptive icon renders correctly (teal background, clean mountain silhouette, no plate artifact) via the task-switcher icon badge, which reads directly from PackageManager
- [x] Verified the monochrome silhouette's alpha-mask geometry by hand — all points fall within/near the 66dp adaptive-icon safe zone