### PR TITLE
test: make IdleWakePolicy tests discriminate on the accuracy gates

### DIFF
--- a/app/src/main/java/com/bizzarosn/heightmark/IdleWakePolicy.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/IdleWakePolicy.kt
@@ -20,7 +20,7 @@ import kotlin.math.abs
  * trigger. Tuned to lean toward the cheaper mistake — reject the fix, not
  * the movement.
  */
-object IdleWakePolicy {
+internal object IdleWakePolicy {
 
     /** True if [location] shows movement from [anchor] worth waking the GPS radio for. */
     fun shouldWake(anchor: Location, location: Location): Boolean =

--- a/app/src/test/java/com/bizzarosn/heightmark/IdleWakePolicyTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/IdleWakePolicyTest.kt
@@ -17,11 +17,22 @@ class IdleWakePolicyTest {
 
     @Test
     fun `coarse fix with large apparent drift but bad accuracy does not wake`() {
-        // A cell-tower fix: hundreds of meters of "movement" that is really its own error
-        val anchor = idleWakeFix(driftMeters = 300f)
+        // A cell-tower fix: drift alone would clear the margin (500 > 30 + 300 = 330),
+        // so only the accuracy gate (accuracy > 50) can be rejecting this fix.
+        val anchor = idleWakeFix(driftMeters = 500f)
         val fix = idleWakeFix(horizontalAccuracy = 300f)
 
         assertFalse(IdleWakePolicy.shouldWake(anchor, fix))
+    }
+
+    @Test
+    fun `same apparent drift with accuracy just under the gate wakes`() {
+        // Same drift as above, but accuracy (49) clears the 50 m gate this time,
+        // pinning the accuracy boundary from the other side.
+        val anchor = idleWakeFix(driftMeters = 500f)
+        val fix = idleWakeFix(horizontalAccuracy = 49f)
+
+        assertTrue(IdleWakePolicy.shouldWake(anchor, fix))
     }
 
     @Test
@@ -73,9 +84,17 @@ class IdleWakePolicyTest {
     }
 
     @Test
-    fun `missing altitude on either fix skips the vertical test`() {
+    fun `missing altitude on anchor skips the vertical test`() {
         val anchor = idleWakeFix(driftMeters = 0f, hasAltitude = false)
         val fix = idleWakeFix(altitude = 200.0, verticalAccuracy = 1f)
+
+        assertFalse(IdleWakePolicy.shouldWake(anchor, fix))
+    }
+
+    @Test
+    fun `missing altitude on fix skips the vertical test`() {
+        val anchor = idleWakeFix(driftMeters = 0f, altitude = 100.0)
+        val fix = idleWakeFix(hasAltitude = false, altitude = 200.0, verticalAccuracy = 1f)
 
         assertFalse(IdleWakePolicy.shouldWake(anchor, fix))
     }


### PR DESCRIPTION
## Summary
- Review advisories on #226 found two tests in `IdleWakePolicyTest` that pass even if the behavior they name is removed.
- `coarse fix with large apparent drift but bad accuracy does not wake` used drift=300/accuracy=300, where the margin math alone already rejects the input (300 > 30 + 300 is false) — deleting the accuracy gate wouldn't break it. Reworked to drift=500/accuracy=300, where drift alone would clear the margin, so only the accuracy gate can be rejecting it. Added a companion case at accuracy=49 (just under the gate) asserting a wake, pinning the boundary from both sides.
- `missing altitude on either fix skips the vertical test` only exercised the anchor-missing branch. Renamed it and added the fix-missing branch so the name is honest.
- Also narrows `IdleWakePolicy` to `internal`, matching the sibling `LocationPermissionPolicy` — nothing outside the module uses it.
- No production behavior changed (verified below).

## Test plan
- [x] Mutation-tested each new/changed assertion by temporarily reintroducing the removed behavior in `IdleWakePolicy` and confirming the corresponding test (and only that test) fails, then restored production code
- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew build` (lint incl. accessibility gates, unit tests, debug+release APKs)