### PR TITLE
fix: explain location permission before the first system prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ The app is a single screen (`ElevationFragment`) plus a set of focused collabora
 - **IdleWakeMonitor**: While GPS is off, wakes on significant motion, sustained barometric pressure change (elevators), passive fixes, or a fallback poll (barometer-less devices only)
 - **PressureDeltaDetector**: Sustained-pressure-change detection with weather-drift absorption and HVAC/door-transient rejection
 - **LocationPermissionHandler**: Lifecycle-aware permission handler with state management, including the Android 12+ coarse-only ("approximate") grant state. Its file also holds the top-level `Context.hasFineLocationPermission()` that both it and `ElevationTracker` gate on
-- **PreferencesRepository**: DataStore-based persistence for user preferences (metric/imperial units, details panel)
+- **PreferencesRepository**: DataStore-based persistence for user preferences (metric/imperial units, details panel, whether the location-permission dialog has ever been requested)
 - **LengthFormatter**: The single home of the metric/imperial branch — value conversion, number formatting, and unit-resource selection. Returns resource IDs for callers to resolve: `Detail` for a panel row, `Hero` for the big number, each pairing a value with the unit that names it
 - **LocationPermissionPolicy**: Pure decision table mapping grant state to a `Resolution` (report a state, show a dialog, or re-request)
 - **UnitConverter**: `object` holding `FEET_PER_METER` and `metersToFeet()`
@@ -74,9 +74,10 @@ Do not "simplify" the remaining five into `@Inject constructor`s; each would eit
 
 ### Permission Handling
 
-- **LocationPermissionState**: Sealed class with states Granted, CoarseOnly, PermanentlyDenied, RequiresRationale
+- **LocationPermissionState**: Sealed class with states Granted, CoarseOnly, PermanentlyDenied, RequiresRationale, NotYetRequested
 - **Lifecycle-aware**: Automatically cleans up dialogs and resources when fragment is destroyed
 - **Multiple permissions**: Handles both ACCESS_FINE_LOCATION and ACCESS_COARSE_LOCATION; coarse-only grants get an in-context precise-location upgrade prompt because GPS requires fine
+- **First launch**: On a true first launch the system permission dialog is not auto-fired. `LocationPermissionPolicy.resolve` takes a `hasRequestedBefore` input — backed by `PreferencesRepository.hasRequestedLocationPermission`, since the distinction must survive process death — that separates "never asked" from "asked before and now stuck at a rationale-less denial" (Android's `shouldShowRequestPermissionRationale` returns false for both). A true first launch resolves to `NotYetRequested`, which renders the same blocked screen as `RequiresRationale` (`Blocked.PermissionRequired`, "Location permission is needed to show your elevation." + Grant Permission button) but with no dialog at all — the blocked message is the up-front rationale, and the user triggers the system dialog themselves via the persistent button. `LocationPermissionHandler.requestPermissions()` is the single choke point that marks the flag, since every request path (the auto-fire fallback, each dialog's positive button, and the blocked screen's button) funnels through it. A returning user who is already permanently denied still gets the old auto-fire-then-silently-redeny fallback, unchanged.
 
 ## Key Technical Details
 

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationFragment.kt
@@ -52,6 +52,7 @@ class ElevationFragment : Fragment() {
 
     private var useMetricUnit = true
     private var showDetails = false
+    private var hasRequestedLocationPermission = false
     private var locationOffDialog: AlertDialog? = null
 
     private lateinit var permissionHandler: LocationPermissionHandler
@@ -63,7 +64,9 @@ class ElevationFragment : Fragment() {
             fragment = this,
             onPermissionStateChanged = { state -> tracker.onPermissionState(state) },
             hasShownUpgradeDialog = { tracker.upgradeDialogShown },
-            onUpgradeDialogShown = { tracker.upgradeDialogShown = true }
+            onUpgradeDialogShown = { tracker.upgradeDialogShown = true },
+            hasRequestedPermissionBefore = { hasRequestedLocationPermission },
+            onPermissionRequested = ::markPermissionRequested
         )
         permissionHandler.initialize()
     }
@@ -104,6 +107,8 @@ class ElevationFragment : Fragment() {
             useMetricUnit = preferencesRepository.useMetricUnit.first()
             unitToggleGroup.check(if (useMetricUnit) R.id.button_meters else R.id.button_feet)
             applyDetailsVisibility(preferencesRepository.showDetails.first())
+            hasRequestedLocationPermission =
+                preferencesRepository.hasRequestedLocationPermission.first()
             permissionHandler.checkPermission()
         }
 
@@ -143,6 +148,19 @@ class ElevationFragment : Fragment() {
         super.onPause()
         tracker.onBackground()
         dismissLocationOffDialog()
+    }
+
+    /**
+     * Records that the system permission dialog has been triggered at least
+     * once, so a later cold start never mistakes a returning, already-decided
+     * user for a true first launch. Persisting on the fragment's scope, not
+     * the view's, for the same reason the toggles do: a rotation right after
+     * the request must not cancel the write.
+     */
+    private fun markPermissionRequested() {
+        if (hasRequestedLocationPermission) return
+        hasRequestedLocationPermission = true
+        lifecycleScope.launch { preferencesRepository.setHasRequestedLocationPermission(true) }
     }
 
     private fun applyDetailsVisibility(show: Boolean) {

--- a/app/src/main/java/com/bizzarosn/heightmark/ElevationTracker.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/ElevationTracker.kt
@@ -115,7 +115,8 @@ class ElevationTracker @Inject constructor(
             }
             is LocationPermissionState.CoarseOnly ->
                 block(ElevationUiState.Blocked.PreciseLocationRequired)
-            is LocationPermissionState.RequiresRationale ->
+            is LocationPermissionState.RequiresRationale,
+            is LocationPermissionState.NotYetRequested ->
                 block(ElevationUiState.Blocked.PermissionRequired)
             is LocationPermissionState.PermanentlyDenied ->
                 block(ElevationUiState.Blocked.PermissionPermanentlyDenied)

--- a/app/src/main/java/com/bizzarosn/heightmark/LocationPermissionHandler.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/LocationPermissionHandler.kt
@@ -33,6 +33,16 @@ sealed class LocationPermissionState {
     object CoarseOnly : LocationPermissionState()
     object PermanentlyDenied : LocationPermissionState()
     object RequiresRationale : LocationPermissionState()
+
+    /**
+     * A true first launch: this install has never triggered the system
+     * permission dialog. Renders the same blocked screen as
+     * [RequiresRationale] — its message is the up-front rationale Android's
+     * guidance calls for — but the caller must not pair it with either
+     * dialog, since firing one here is exactly the no-context prompt this
+     * state exists to avoid.
+     */
+    object NotYetRequested : LocationPermissionState()
 }
 
 class LocationPermissionHandler(
@@ -42,7 +52,14 @@ class LocationPermissionHandler(
      *  caller backs this with session-scoped state, since this handler is
      *  rebuilt on every fragment recreation and cannot hold it itself. */
     private val hasShownUpgradeDialog: () -> Boolean,
-    private val onUpgradeDialogShown: () -> Unit
+    private val onUpgradeDialogShown: () -> Unit,
+    /** Whether the system dialog has ever been triggered for this install —
+     *  the seam [checkPermission] uses to tell a true first launch apart
+     *  from a returning, already-decided user. The caller backs this with
+     *  persisted state (survives process death, unlike [hasShownUpgradeDialog]),
+     *  since a killed-and-relaunched process must not re-ask. */
+    private val hasRequestedPermissionBefore: () -> Boolean,
+    private val onPermissionRequested: () -> Unit
 ) : DefaultLifecycleObserver {
 
     private var locationPermissionLauncher: ActivityResultLauncher<Array<String>>? = null
@@ -74,7 +91,8 @@ class LocationPermissionHandler(
                 fineGranted = hasFinePermission(),
                 anyGranted = hasLocationPermission(),
                 shouldShowRationale = shouldShowRationale(),
-                isRequestResult = false
+                isRequestResult = false,
+                hasRequestedBefore = hasRequestedPermissionBefore()
             )
         )
     }
@@ -100,16 +118,25 @@ class LocationPermissionHandler(
     /** Launches the system permission request. Also the blocked screen's
      *  persistent-action entry point for [ElevationUiState.BlockedAction.RequestPermission]. */
     fun requestPermissions() {
+        // The single choke point every request path funnels through — the
+        // auto-fire fallback, each dialog's positive button, and the blocked
+        // screen's own button — so "requested at least once" is recorded
+        // regardless of which of them the user reached it from.
+        onPermissionRequested()
         locationPermissionLauncher?.launch(permissions)
     }
-    
+
     private fun handlePermissionResult(permissions: Map<String, Boolean>) {
         applyResolution(
             LocationPermissionPolicy.resolve(
                 fineGranted = permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true,
                 anyGranted = permissions.values.any { it },
                 shouldShowRationale = shouldShowRationale(),
-                isRequestResult = true
+                isRequestResult = true,
+                // A result callback only fires after a request, so this is
+                // trivially true — read directly rather than through the
+                // persisted flag, which may still be mid-write.
+                hasRequestedBefore = true
             )
         )
     }

--- a/app/src/main/java/com/bizzarosn/heightmark/LocationPermissionPolicy.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/LocationPermissionPolicy.kt
@@ -6,6 +6,16 @@ package com.bizzarosn.heightmark
  * [LocationPermissionHandler]. The two paths differ only in their fallback:
  * an initial check can still launch the system request, while a denied
  * request result means the system dialog can no longer be shown.
+ *
+ * [hasRequestedBefore] disambiguates the one case Android's own APIs can't:
+ * `shouldShowRequestPermissionRationale` returning false means either "never
+ * asked" or "permanently denied", and only the caller's own persisted record
+ * of ever having launched the system dialog tells those apart. A true first
+ * launch lands on the blocked screen's own explanation instead of firing the
+ * system dialog with no context; a returning, already-permanently-denied
+ * user still gets the old auto-fire fallback, which resolves back to
+ * [LocationPermissionState.PermanentlyDenied] once the system silently
+ * re-denies it.
  */
 internal object LocationPermissionPolicy {
 
@@ -23,7 +33,8 @@ internal object LocationPermissionPolicy {
         fineGranted: Boolean,
         anyGranted: Boolean,
         shouldShowRationale: Boolean,
-        isRequestResult: Boolean
+        isRequestResult: Boolean,
+        hasRequestedBefore: Boolean
     ): Resolution = when {
         fineGranted -> Resolution.Report(LocationPermissionState.Granted, null)
 
@@ -39,6 +50,12 @@ internal object LocationPermissionPolicy {
         isRequestResult -> Resolution.Report(
             LocationPermissionState.PermanentlyDenied, Dialog.PermanentDenial
         )
+
+        // Nothing granted, no rationale owed, and not a request result: only
+        // reachable by a plain check. Without a prior request this is a true
+        // first launch — explain in place and let the user trigger the
+        // system dialog themselves, per Android's contextual-priming guidance.
+        !hasRequestedBefore -> Resolution.Report(LocationPermissionState.NotYetRequested, null)
 
         else -> Resolution.RequestPermissions
     }

--- a/app/src/main/java/com/bizzarosn/heightmark/PreferencesRepository.kt
+++ b/app/src/main/java/com/bizzarosn/heightmark/PreferencesRepository.kt
@@ -24,6 +24,9 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
 private object PreferencesKeys {
     val USE_METRIC_UNIT = booleanPreferencesKey("use_metric_unit")
     val SHOW_DETAILS = booleanPreferencesKey("show_details")
+    val HAS_REQUESTED_LOCATION_PERMISSION = booleanPreferencesKey(
+        "has_requested_location_permission"
+    )
 }
 
 @Singleton
@@ -42,6 +45,21 @@ class PreferencesRepository @Inject constructor(@ApplicationContext context: Con
 
     suspend fun setShowDetails(show: Boolean) {
         setBoolean(PreferencesKeys.SHOW_DETAILS, show)
+    }
+
+    /**
+     * Whether this install has ever triggered the system location-permission
+     * dialog. Persisted, not session state: [LocationPermissionPolicy] uses
+     * it to tell a true first launch (land on the blocked screen's own
+     * explanation, no dialog) apart from a returning user the OS can no
+     * longer show a rationale for — a distinction that must survive the
+     * process dying between sessions, which a ViewModel-held flag would not.
+     */
+    val hasRequestedLocationPermission: Flow<Boolean> =
+        booleanFlow(PreferencesKeys.HAS_REQUESTED_LOCATION_PERMISSION, default = false)
+
+    suspend fun setHasRequestedLocationPermission(requested: Boolean) {
+        setBoolean(PreferencesKeys.HAS_REQUESTED_LOCATION_PERMISSION, requested)
     }
 
     private fun booleanFlow(key: Preferences.Key<Boolean>, default: Boolean): Flow<Boolean> =

--- a/app/src/test/java/com/bizzarosn/heightmark/LocationPermissionPolicyTest.kt
+++ b/app/src/test/java/com/bizzarosn/heightmark/LocationPermissionPolicyTest.kt
@@ -8,7 +8,9 @@ import org.junit.Test
 /**
  * Locks in the permission decision table. The expectations mirror the two
  * historical when-chains in LocationPermissionHandler (checkPermission and
- * handlePermissionResult), which this policy replaced.
+ * handlePermissionResult), which this policy replaced, plus the
+ * [hasRequestedBefore] branch that tells a true first launch apart from a
+ * returning, already-permanently-denied user.
  */
 class LocationPermissionPolicyTest {
 
@@ -16,12 +18,14 @@ class LocationPermissionPolicyTest {
         fine: Boolean = false,
         any: Boolean = false,
         rationale: Boolean = false,
-        isResult: Boolean
+        isResult: Boolean,
+        hasRequestedBefore: Boolean = true
     ) = LocationPermissionPolicy.resolve(
         fineGranted = fine,
         anyGranted = any,
         shouldShowRationale = rationale,
-        isRequestResult = isResult
+        isRequestResult = isResult,
+        hasRequestedBefore = hasRequestedBefore
     )
 
     @Test
@@ -29,10 +33,16 @@ class LocationPermissionPolicyTest {
         for (isResult in listOf(false, true)) {
             // fineGranted implies anyGranted in practice; both shapes resolve the same
             for (any in listOf(false, true)) {
-                assertEquals(
-                    Resolution.Report(LocationPermissionState.Granted, null),
-                    resolve(fine = true, any = any, isResult = isResult)
-                )
+                // hasRequestedBefore must not matter once fine is granted
+                for (hasRequestedBefore in listOf(false, true)) {
+                    assertEquals(
+                        Resolution.Report(LocationPermissionState.Granted, null),
+                        resolve(
+                            fine = true, any = any, isResult = isResult,
+                            hasRequestedBefore = hasRequestedBefore
+                        )
+                    )
+                }
             }
         }
     }
@@ -40,12 +50,19 @@ class LocationPermissionPolicyTest {
     @Test
     fun `coarse-only grant reports CoarseOnly with the upgrade dialog on both paths`() {
         for (isResult in listOf(false, true)) {
-            // rationale must not matter once something is granted
+            // rationale and hasRequestedBefore must not matter once something is granted
             for (rationale in listOf(false, true)) {
-                assertEquals(
-                    Resolution.Report(LocationPermissionState.CoarseOnly, Dialog.PreciseUpgrade),
-                    resolve(any = true, rationale = rationale, isResult = isResult)
-                )
+                for (hasRequestedBefore in listOf(false, true)) {
+                    assertEquals(
+                        Resolution.Report(
+                            LocationPermissionState.CoarseOnly, Dialog.PreciseUpgrade
+                        ),
+                        resolve(
+                            any = true, rationale = rationale, isResult = isResult,
+                            hasRequestedBefore = hasRequestedBefore
+                        )
+                    )
+                }
             }
         }
     }
@@ -53,25 +70,46 @@ class LocationPermissionPolicyTest {
     @Test
     fun `nothing granted with rationale reports RequiresRationale on both paths`() {
         for (isResult in listOf(false, true)) {
+            // hasRequestedBefore must not matter once a rationale is owed
+            for (hasRequestedBefore in listOf(false, true)) {
+                assertEquals(
+                    Resolution.Report(
+                        LocationPermissionState.RequiresRationale, Dialog.PermissionRequired
+                    ),
+                    resolve(
+                        rationale = true, isResult = isResult,
+                        hasRequestedBefore = hasRequestedBefore
+                    )
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a request result always reports PermanentlyDenied regardless of hasRequestedBefore`() {
+        for (hasRequestedBefore in listOf(false, true)) {
             assertEquals(
                 Resolution.Report(
-                    LocationPermissionState.RequiresRationale, Dialog.PermissionRequired
+                    LocationPermissionState.PermanentlyDenied, Dialog.PermanentDenial
                 ),
-                resolve(rationale = true, isResult = isResult)
+                resolve(isResult = true, hasRequestedBefore = hasRequestedBefore)
             )
         }
     }
 
     @Test
-    fun `nothing granted and no rationale requests permissions on the check path`() {
-        assertEquals(Resolution.RequestPermissions, resolve(isResult = false))
+    fun `a true first launch reports NotYetRequested with no dialog on the check path`() {
+        assertEquals(
+            Resolution.Report(LocationPermissionState.NotYetRequested, null),
+            resolve(isResult = false, hasRequestedBefore = false)
+        )
     }
 
     @Test
-    fun `nothing granted and no rationale is a permanent denial on the result path`() {
+    fun `a returning already-denied user requests permissions on the check path`() {
         assertEquals(
-            Resolution.Report(LocationPermissionState.PermanentlyDenied, Dialog.PermanentDenial),
-            resolve(isResult = true)
+            Resolution.RequestPermissions,
+            resolve(isResult = false, hasRequestedBefore = true)
         )
     }
 }


### PR DESCRIPTION
## Summary
- On a true first launch, land on the existing blocked-screen explanation ("Location permission is needed to show your elevation.") and Grant Permission button instead of firing the system permission dialog with zero context.
- `LocationPermissionPolicy.resolve` gains a `hasRequestedBefore` input to tell a never-asked install apart from a returning user stuck at a rationale-less denial — a distinction Android's `shouldShowRequestPermissionRationale` alone can't make. Backed by a new persisted `PreferencesRepository` flag, since the distinction must survive process death.
- New `LocationPermissionState.NotYetRequested` renders through the same blocked screen as `RequiresRationale`, but with no dialog at all — the blocked message is the up-front rationale. `LocationPermissionHandler.requestPermissions()` is the single choke point that marks the flag, so every request path (auto-fire fallback, dialog buttons, blocked-screen button) sets it once.
- Already-granted users, coarse-only, rationale, and permanently-denied-request-result flows are all unchanged.

## Test plan
- [x] `./gradlew build` (unit tests, accessibility-as-error lint, debug + release assembly)
- [x] `./gradlew connectedDebugAndroidTest` — all 14 instrumented tests pass (1 pre-existing, documented skip unrelated to this change)
- [x] Extended `LocationPermissionPolicyTest` covering the new branch and confirming `hasRequestedBefore` doesn't perturb existing branches